### PR TITLE
feat: auto-detect language in init and share config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .venv/
 node_modules/
 apps/openant-cli/bin/
+.build/
 docs/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 node_modules/
 apps/openant-cli/bin/
 docs/
+.worktrees/

--- a/apps/openant-cli/cmd/init.go
+++ b/apps/openant-cli/cmd/init.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,12 +22,16 @@ var initCmd = &cobra.Command{
 For remote URLs, the repo is cloned into ~/.openant/projects/{org}/{repo}/repo/.
 For local paths, the existing directory is referenced in place (no cloning).
 
+If --language is not specified, the dominant language is auto-detected by
+counting source files in the repository.
+
 After init, all commands (parse, scan, etc.) work without path arguments.
 
 Examples:
+  openant init https://github.com/grafana/grafana
   openant init https://github.com/grafana/grafana -l go
   openant init https://github.com/grafana/grafana -l go --commit 591ceb2eec0
-  openant init ./repos/grafana -l go
+  openant init ./repos/grafana
   openant init ./repos/grafana -l go --name myorg/grafana`,
 	Args: cobra.ExactArgs(1),
 	Run:  runInit,
@@ -38,10 +44,9 @@ var (
 )
 
 func init() {
-	initCmd.Flags().StringVarP(&initLanguage, "language", "l", "", "Language to analyze: python, javascript, go, c, ruby, php (required)")
+	initCmd.Flags().StringVarP(&initLanguage, "language", "l", "", "Language to analyze: python, javascript, go, c, ruby, php, auto (default: auto-detect)")
 	initCmd.Flags().StringVar(&initCommit, "commit", "", "Specific commit SHA (default: HEAD)")
 	initCmd.Flags().StringVar(&initName, "name", "", "Override project name (default: derived from URL/path)")
-	_ = initCmd.MarkFlagRequired("language")
 }
 
 func runInit(cmd *cobra.Command, args []string) {
@@ -107,7 +112,7 @@ func runInit(cmd *cobra.Command, args []string) {
 			}
 		}
 	} else {
-		// Local: verify it's a git repo and resolve absolute path
+		// Local: resolve absolute path
 		source = "local"
 
 		absPath, err := filepath.Abs(input)
@@ -116,29 +121,48 @@ func runInit(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		if _, err := os.Stat(filepath.Join(absPath, ".git")); err != nil {
-			output.PrintError(fmt.Sprintf("%s is not a git repository (no .git directory)", absPath))
-			os.Exit(1)
-		}
-
 		repoPath = absPath
 	}
 
-	// Get commit SHA
-	commitSHA := initCommit
-	if commitSHA == "" {
-		out, err := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+	// Auto-detect language if not specified
+	if initLanguage == "" || initLanguage == "auto" {
+		fmt.Fprintf(os.Stderr, "Auto-detecting language...\n")
+		detected, err := detectLanguage(repoPath)
 		if err != nil {
-			output.PrintError(fmt.Sprintf("Failed to get HEAD commit: %s", err))
+			output.PrintError(fmt.Sprintf("Language auto-detection failed: %s\nSpecify manually with -l/--language", err))
 			os.Exit(1)
 		}
-		commitSHA = strings.TrimSpace(string(out))
-	} else {
-		// Resolve short SHA to full SHA
-		out, err := exec.Command("git", "-C", repoPath, "rev-parse", commitSHA).Output()
-		if err == nil {
+		initLanguage = detected
+		fmt.Fprintf(os.Stderr, "Detected language: %s\n", initLanguage)
+	}
+
+	// Get commit SHA (best-effort — not all local paths are git repos)
+	isGit := false
+	if _, err := os.Stat(filepath.Join(repoPath, ".git")); err == nil {
+		isGit = true
+	}
+
+	commitSHA := initCommit
+	if isGit {
+		if commitSHA == "" {
+			out, err := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+			if err != nil {
+				output.PrintError(fmt.Sprintf("Failed to get HEAD commit: %s", err))
+				os.Exit(1)
+			}
 			commitSHA = strings.TrimSpace(string(out))
+		} else {
+			// Resolve short SHA to full SHA
+			out, err := exec.Command("git", "-C", repoPath, "rev-parse", commitSHA).Output()
+			if err == nil {
+				commitSHA = strings.TrimSpace(string(out))
+			}
 		}
+	} else {
+		if commitSHA != "" {
+			output.PrintWarning("--commit ignored: not a git repository")
+		}
+		commitSHA = "nogit"
 	}
 
 	// Create project
@@ -183,4 +207,126 @@ func runInit(cmd *cobra.Command, args []string) {
 	fmt.Println()
 	output.PrintSuccess("Set as active project")
 	fmt.Println()
+}
+
+// languagesConfig is the structure of config/languages.json.
+type languagesConfig struct {
+	SkipDirs   []string          `json:"skip_dirs"`
+	Extensions map[string]string `json:"extensions"`
+}
+
+// findLanguagesConfig locates config/languages.json by walking up from the
+// executable path and then the current working directory.
+func findLanguagesConfig() (string, error) {
+	rel := filepath.Join("config", "languages.json")
+
+	// Strategy 1: walk up from the executable.
+	if exePath, err := os.Executable(); err == nil {
+		exePath, _ = filepath.EvalSymlinks(exePath)
+		dir := filepath.Dir(exePath)
+		for range 6 {
+			candidate := filepath.Join(dir, rel)
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+
+	// Strategy 2: walk up from CWD.
+	if cwd, err := os.Getwd(); err == nil {
+		dir := cwd
+		for range 6 {
+			candidate := filepath.Join(dir, rel)
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+
+	return "", fmt.Errorf("could not find config/languages.json from executable or working directory")
+}
+
+// loadLanguagesConfig loads the shared language detection config.
+func loadLanguagesConfig() (*languagesConfig, error) {
+	path, err := findLanguagesConfig()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	var cfg languagesConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// detectLanguage walks a repository and returns the dominant language by file count.
+// Extension mappings and skip directories are loaded from config/languages.json
+// (shared with libs/openant-core/core/parser_adapter.py::detect_language()).
+func detectLanguage(repoPath string) (string, error) {
+	cfg, err := loadLanguagesConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load language config: %w", err)
+	}
+
+	skipDirs := make(map[string]bool, len(cfg.SkipDirs))
+	for _, d := range cfg.SkipDirs {
+		skipDirs[d] = true
+	}
+
+	counts := make(map[string]int)
+
+	err = filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible paths
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if lang, ok := cfg.Extensions[ext]; ok {
+			counts[lang]++
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to walk repository: %w", err)
+	}
+
+	// Find the dominant language
+	bestLang := ""
+	bestCount := 0
+	for lang, count := range counts {
+		if count > bestCount {
+			bestCount = count
+			bestLang = lang
+		}
+	}
+
+	if bestLang == "" {
+		return "", fmt.Errorf(
+			"no supported source files found in %s. "+
+				"Supported languages: Python, JavaScript/TypeScript, Go, C/C++, Ruby, PHP",
+			repoPath,
+		)
+	}
+
+	return bestLang, nil
 }

--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -82,9 +82,7 @@ func runParse(cmd *cobra.Command, args []string) {
 	if parseLanguage != "auto" {
 		pyArgs = append(pyArgs, "--language", parseLanguage)
 	}
-	if parseLevel != "all" {
-		pyArgs = append(pyArgs, "--level", parseLevel)
-	}
+	pyArgs = append(pyArgs, "--level", parseLevel)
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, resolvedAPIKey())
 	if err != nil {

--- a/config/languages.json
+++ b/config/languages.json
@@ -1,0 +1,33 @@
+{
+  "skip_dirs": [
+    "node_modules",
+    "__pycache__",
+    "venv",
+    ".venv",
+    "dist",
+    "build",
+    ".git",
+    "vendor"
+  ],
+  "extensions": {
+    ".py": "python",
+    ".js": "javascript",
+    ".ts": "javascript",
+    ".jsx": "javascript",
+    ".tsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".go": "go",
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "c",
+    ".hpp": "c",
+    ".cc": "c",
+    ".cxx": "c",
+    ".hxx": "c",
+    ".hh": "c",
+    ".rb": "ruby",
+    ".rake": "ruby",
+    ".php": "php"
+  }
+}

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -20,44 +20,45 @@ from core.schemas import ParseResult
 # Root of openant-core (where parsers/ lives)
 _CORE_ROOT = Path(__file__).parent.parent
 
+# Shared language detection config (single source of truth: config/languages.json)
+_LANGUAGES_CONFIG = Path(__file__).parent.parent.parent.parent / "config" / "languages.json"
+
+
+def _load_language_config() -> dict:
+    """Load language detection config from the shared config/languages.json."""
+    with open(_LANGUAGES_CONFIG) as f:
+        return json.load(f)
+
 
 def detect_language(repo_path: str) -> str:
     """Auto-detect the primary language of a repository.
 
     Counts source files by extension and returns the dominant language.
+    Extension mappings and skip directories are loaded from config/languages.json.
 
     Returns:
-        "python", "javascript", or "go"
+        One of: "python", "javascript", "go", "c", "ruby", "php"
     """
+    config = _load_language_config()
+    skip_dirs = set(config["skip_dirs"])
+    extensions = config["extensions"]
+
     repo = Path(repo_path)
-    counts = {"python": 0, "javascript": 0, "go": 0, "c": 0, "ruby": 0, "php": 0}
+    counts: dict[str, int] = {}
 
     for f in repo.rglob("*"):
         if not f.is_file():
             continue
-        # Skip common non-source dirs
-        parts = f.parts
-        if any(p in parts for p in (
-            "node_modules", "__pycache__", "venv", ".venv",
-            "dist", "build", ".git", "vendor",
-        )):
+        # Skip configured non-source dirs
+        if any(p in skip_dirs for p in f.parts):
             continue
 
         suffix = f.suffix.lower()
-        if suffix == ".py":
-            counts["python"] += 1
-        elif suffix in (".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"):
-            counts["javascript"] += 1
-        elif suffix == ".go":
-            counts["go"] += 1
-        elif suffix in (".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".hxx", ".hh"):
-            counts["c"] += 1
-        elif suffix in (".rb", ".rake"):
-            counts["ruby"] += 1
-        elif suffix == ".php":
-            counts["php"] += 1
+        if suffix in extensions:
+            lang = extensions[suffix]
+            counts[lang] = counts.get(lang, 0) + 1
 
-    if not any(counts.values()):
+    if not counts:
         raise ValueError(
             f"No supported source files found in {repo_path}. "
             "Supported languages: Python, JavaScript/TypeScript, Go, C/C++, Ruby, PHP."

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -13,17 +13,22 @@ from pathlib import Path
 
 import pytest
 
-CLI_DIR = Path(__file__).parent.parent.parent.parent / "apps" / "openant-cli"
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+CLI_DIR = REPO_ROOT / "apps" / "openant-cli"
 BINARY_NAME = "openant.exe" if sys.platform == "win32" else "openant"
-BINARY = CLI_DIR / BINARY_NAME
+
+# Build into .build/ within the repo (gitignored) to avoid polluting source dirs.
+_BUILD_DIR = REPO_ROOT / ".build"
+BINARY = _BUILD_DIR / BINARY_NAME
 
 
 def _build_binary():
-    """Build the Go CLI binary if it doesn't exist."""
+    """Build the Go CLI binary into .build/ within the repo."""
     if BINARY.exists():
         return
     if not shutil.which("go"):
         pytest.skip("Go toolchain not installed")
+    _BUILD_DIR.mkdir(exist_ok=True)
     result = subprocess.run(
         ["go", "build", "-o", str(BINARY), "."],
         cwd=str(CLI_DIR),
@@ -37,8 +42,12 @@ def _build_binary():
 
 @pytest.fixture(autouse=True, scope="session")
 def ensure_binary():
-    """Build the Go CLI binary once per test session."""
+    """Build the Go CLI binary once per test session, clean up after."""
     _build_binary()
+    yield
+    # Clean up build artifacts
+    if _BUILD_DIR.exists():
+        shutil.rmtree(_BUILD_DIR, ignore_errors=True)
 
 
 def run_cli(*args, env_override=None):
@@ -91,56 +100,6 @@ class TestHelp:
 
 
 class TestParse:
-    def test_parse_python_repo(self, sample_python_repo, tmp_path):
-        output_dir = str(tmp_path / "output")
-        result = run_cli(
-            "parse", sample_python_repo,
-            "--output", output_dir,
-            "--language", "python",
-            "--json",
-        )
-        assert result.returncode == 0
-
-        envelope = json.loads(result.stdout)
-        assert envelope["status"] == "success"
-
-    def test_parse_produces_dataset(self, sample_python_repo, tmp_path):
-        output_dir = str(tmp_path / "output")
-        run_cli(
-            "parse", sample_python_repo,
-            "--output", output_dir,
-            "--language", "python",
-        )
-        dataset = Path(output_dir) / "dataset.json"
-        assert dataset.exists()
-        data = json.loads(dataset.read_text())
-        assert "units" in data
-        assert len(data["units"]) > 0
-
-    def test_parse_auto_detect(self, sample_python_repo, tmp_path):
-        output_dir = str(tmp_path / "output")
-        result = run_cli(
-            "parse", sample_python_repo,
-            "--output", output_dir,
-            "--json",
-        )
-        assert result.returncode == 0
-        envelope = json.loads(result.stdout)
-        assert envelope["status"] == "success"
-
-    def test_parse_js_repo(self, sample_js_repo, tmp_path):
-        """JS parsing via Go CLI."""
-        output_dir = str(tmp_path / "output")
-        result = run_cli(
-            "parse", sample_js_repo,
-            "--output", output_dir,
-            "--language", "javascript",
-            "--json",
-        )
-        assert result.returncode == 0, f"JS parse failed:\n{result.stderr}"
-        envelope = json.loads(result.stdout)
-        assert envelope["status"] == "success"
-
     def test_parse_missing_repo(self, tmp_path):
         result = run_cli(
             "parse", str(tmp_path / "nonexistent"),
@@ -158,6 +117,303 @@ class TestParse:
         # Should always produce valid JSON on stdout when --json is used
         envelope = json.loads(result.stdout)
         assert "status" in envelope
+
+
+class TestParsePython:
+    """Integration tests for parsing Python repos via the Go CLI."""
+
+    def test_parse_succeeds(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        result = run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+            "--json",
+        )
+        assert result.returncode == 0
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "success"
+
+    def test_produces_dataset_and_analyzer_output(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+        )
+        assert (Path(output_dir) / "dataset.json").exists()
+        assert (Path(output_dir) / "analyzer_output.json").exists()
+
+    def test_dataset_has_units(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        assert "units" in data
+        assert len(data["units"]) > 0
+
+    def test_units_have_code_and_id(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        for unit in data["units"]:
+            assert "id" in unit, f"Unit missing 'id': {unit}"
+            assert "code" in unit, f"Unit missing 'code': {unit}"
+
+    def test_finds_flask_route_handlers(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+            "--level", "all",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        unit_ids = [u["id"] for u in data["units"]]
+        # Sample repo has get_user_endpoint and create_user_endpoint
+        assert any("get_user_endpoint" in uid for uid in unit_ids)
+        assert any("create_user_endpoint" in uid for uid in unit_ids)
+
+    def test_auto_detects_python(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        result = run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--json",
+        )
+        assert result.returncode == 0
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "success"
+        assert envelope["data"]["language"] == "python"
+
+    def test_produces_step_report(self, sample_python_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_python_repo,
+            "--output", output_dir,
+            "--language", "python",
+        )
+        report = Path(output_dir) / "parse.report.json"
+        assert report.exists()
+        data = json.loads(report.read_text())
+        assert data["step"] == "parse"
+        assert data["status"] == "success"
+
+
+class TestParseJavaScript:
+    """Integration tests for parsing JavaScript repos via the Go CLI."""
+
+    def test_parse_succeeds(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        result = run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+            "--json",
+        )
+        assert result.returncode == 0, f"JS parse failed:\n{result.stderr}"
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "success"
+
+    def test_produces_dataset_and_analyzer_output(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+        )
+        assert (Path(output_dir) / "dataset.json").exists()
+        assert (Path(output_dir) / "analyzer_output.json").exists()
+
+    def test_dataset_has_units(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+            "--level", "all",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        assert "units" in data
+        assert len(data["units"]) > 0
+
+    def test_units_have_code_and_id(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+            "--level", "all",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        for unit in data["units"]:
+            assert "id" in unit, f"Unit missing 'id': {unit}"
+            assert "code" in unit, f"Unit missing 'code': {unit}"
+
+    def test_finds_known_functions(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+            "--level", "all",
+        )
+        data = json.loads((Path(output_dir) / "dataset.json").read_text())
+        unit_ids = [u["id"] for u in data["units"]]
+        # Sample repo has getUser, createUser, getConnection
+        assert any("getUser" in uid for uid in unit_ids)
+        assert any("createUser" in uid for uid in unit_ids)
+        assert any("getConnection" in uid for uid in unit_ids)
+
+    def test_auto_detects_javascript(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        result = run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--json",
+        )
+        assert result.returncode == 0, f"JS auto-detect failed:\n{result.stderr}"
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "success"
+        assert envelope["data"]["language"] == "javascript"
+
+    def test_produces_step_report(self, sample_js_repo, tmp_path):
+        output_dir = str(tmp_path / "output")
+        run_cli(
+            "parse", sample_js_repo,
+            "--output", output_dir,
+            "--language", "javascript",
+        )
+        report = Path(output_dir) / "parse.report.json"
+        assert report.exists()
+        data = json.loads(report.read_text())
+        assert data["step"] == "parse"
+        assert data["status"] == "success"
+
+
+class TestInit:
+    """Tests for `openant init` with auto-detect and non-git support."""
+
+    @pytest.fixture
+    def isolated_home(self, tmp_path):
+        """Override home directory so init doesn't pollute real ~/.openant/."""
+        home = str(tmp_path / "fakehome")
+        os.makedirs(home)
+        # USERPROFILE for Windows, HOME for Unix
+        return {"USERPROFILE": home, "HOME": home}
+
+    def _read_project_json(self, home_dir, project_name):
+        """Read project.json created by init."""
+        project_json = Path(home_dir) / ".openant" / "projects" / project_name / "project.json"
+        assert project_json.exists(), f"project.json not found at {project_json}"
+        return json.loads(project_json.read_text())
+
+    def test_init_auto_detect_python(self, sample_python_repo, isolated_home, tmp_path):
+        """Init without -l should auto-detect Python."""
+        result = run_cli(
+            "init", sample_python_repo,
+            "--name", "test/python-repo",
+            env_override=isolated_home,
+        )
+        assert result.returncode == 0, f"init failed:\n{result.stderr}"
+        assert "Detected language: python" in result.stderr
+        assert "python" in result.stderr
+
+        project = self._read_project_json(
+            isolated_home["HOME"], "test/python-repo",
+        )
+        assert project["language"] == "python"
+
+    def test_init_auto_detect_javascript(self, sample_js_repo, isolated_home, tmp_path):
+        """Init without -l should auto-detect JavaScript."""
+        result = run_cli(
+            "init", sample_js_repo,
+            "--name", "test/js-repo",
+            env_override=isolated_home,
+        )
+        assert result.returncode == 0, f"init failed:\n{result.stderr}"
+        assert "Detected language: javascript" in result.stderr
+
+        project = self._read_project_json(
+            isolated_home["HOME"], "test/js-repo",
+        )
+        assert project["language"] == "javascript"
+
+    def test_init_explicit_language(self, sample_python_repo, isolated_home):
+        """Init with explicit -l should use specified language."""
+        result = run_cli(
+            "init", sample_python_repo,
+            "--name", "test/explicit-lang",
+            "-l", "go",
+            env_override=isolated_home,
+        )
+        assert result.returncode == 0, f"init failed:\n{result.stderr}"
+        assert "Auto-detecting" not in result.stderr
+
+        project = self._read_project_json(
+            isolated_home["HOME"], "test/explicit-lang",
+        )
+        assert project["language"] == "go"
+
+    def test_init_non_git_directory(self, tmp_path, isolated_home):
+        """Init on a plain directory (no .git) should work with 'nogit' commit."""
+        repo = tmp_path / "plain_repo"
+        repo.mkdir()
+        (repo / "main.py").write_text("print('hello')")
+
+        result = run_cli(
+            "init", str(repo),
+            "--name", "test/no-git",
+            env_override=isolated_home,
+        )
+        assert result.returncode == 0, f"init failed:\n{result.stderr}"
+
+        project = self._read_project_json(
+            isolated_home["HOME"], "test/no-git",
+        )
+        assert project["language"] == "python"
+        assert project["commit_sha"] == "nogit"
+        assert project["commit_sha_short"] == "nogit"
+
+    def test_init_non_git_ignores_commit_flag(self, tmp_path, isolated_home):
+        """--commit on a non-git directory should warn and use 'nogit'."""
+        repo = tmp_path / "plain_repo"
+        repo.mkdir()
+        (repo / "main.py").write_text("print('hello')")
+
+        result = run_cli(
+            "init", str(repo),
+            "--name", "test/no-git-commit",
+            "--commit", "abc123",
+            env_override=isolated_home,
+        )
+        assert result.returncode == 0, f"init failed:\n{result.stderr}"
+        assert "ignored" in result.stderr.lower()
+
+        project = self._read_project_json(
+            isolated_home["HOME"], "test/no-git-commit",
+        )
+        assert project["commit_sha"] == "nogit"
+
+    def test_init_empty_dir_fails(self, tmp_path, isolated_home):
+        """Init on an empty directory should fail (no supported source files)."""
+        empty = tmp_path / "empty_repo"
+        empty.mkdir()
+
+        result = run_cli(
+            "init", str(empty),
+            "--name", "test/empty",
+            env_override=isolated_home,
+        )
+        assert result.returncode != 0
+        assert "no supported source files" in (result.stderr + result.stdout).lower()
 
 
 class TestApiKeyHandling:


### PR DESCRIPTION
## Summary

- Make `--language` optional in `openant init` — auto-detects by counting source files when omitted
- Make git repository optional for local paths — uses `"nogit"` placeholder for commit SHA
- Add shared `config/languages.json` for file extension mappings (single source of truth for both Go and Python)
- Fix `parse.go`: always pass `--level` to Python CLI (was silently dropping `--level all`, causing Python to default to `reachable`)
- Build test binary into `.build/` (gitignored) instead of source tree, with cleanup after test session

## Test plan

- [x] 6 init integration tests: auto-detect Python/JS, explicit language, non-git directory, `--commit` ignored warning, empty dir failure
- [x] 14 parse integration tests (7 Python + 7 JS): dataset content, unit fields, known function discovery, auto-detect, step reports
- [x] Full suite: 91 passed, 0 failed, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)