### PR TITLE
fix: correct findings count in build-output and verify cached results

### DIFF
--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -83,13 +83,17 @@ def run_verification(
             confirmed_vulnerabilities = 0
             findings_input = 0
             for r in verified_data.get("results", []):
+                # Count vulnerable/bypassable findings as input
+                # (matches the fresh verification path's filtering logic)
+                finding = r.get("finding", r.get("verdict", "")).lower()
+                if finding in ("vulnerable", "bypassable"):
+                    findings_input += 1
+
                 verification = r.get("verification")
                 if verification is None:
                     continue
-                findings_input += 1
                 if verification.get("agree", False):
                     agreed += 1
-                    finding = r.get("finding", "").lower()
                     if finding in ("vulnerable", "bypassable"):
                         confirmed_vulnerabilities += 1
                 else:

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -272,6 +272,7 @@ def _write_verified_results(
         "verify": True,
         "metrics": experiment.get("metrics", {}),
         "results": merged_results,
+        "code_by_route": experiment.get("code_by_route", {}),
         "confirmed_findings": [
             r for r in verified_only
             if r.get("verification", {}).get("agree", False)

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -323,7 +323,19 @@ def cmd_build_output(args):
 
             ctx.outputs = {"pipeline_output_path": path}
 
-        _output_json(success({"pipeline_output_path": path}))
+        # Read back the generated file to extract findings count
+        findings_count = 0
+        try:
+            with open(path) as f:
+                pipeline_data = json.load(f)
+            findings_count = len(pipeline_data.get("findings", []))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+        _output_json(success({
+            "pipeline_output_path": path,
+            "findings_count": findings_count,
+        }))
         return 0
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- **build-output**: Python CLI returned `{"pipeline_output_path": path}` without a `findings_count` field, so Go's `PrintBuildOutputSummary` displayed "Findings included: 0". Now reads back the generated file and includes `findings_count` in the response.
- **verify cached path**: The "Already complete" early-return counted only results with a `verification` field, missing vulnerable/bypassable results that were the actual input. Now counts vulnerable/bypassable findings to match the fresh verification path's logic.

## Test plan
- [x] 162 tests pass
- [x] `ruff check` clean
- [ ] Run `openant build-output` and verify findings count matches
- [ ] Run `openant verify` (cached) and verify findings_input is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)