### PR TITLE
fix: centralize file I/O with UTF-8 encoding for Windows compatibility

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
+from utilities.file_io import read_json, write_json
 from utilities.llm_client import create_anthropic_client, create_message
 
 # Load environment variables
@@ -544,8 +545,7 @@ def save_context(context: ApplicationContext, output_path: Path) -> None:
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(output_path, 'w') as f:
-        json.dump(asdict(context), f, indent=2)
+    write_json(output_path, asdict(context))
 
     print(f"Context saved to {output_path}", file=sys.stderr)
 
@@ -559,8 +559,7 @@ def load_context(input_path: Path) -> ApplicationContext:
     Returns:
         ApplicationContext loaded from file.
     """
-    with open(input_path) as f:
-        data = json.load(f)
+    data = read_json(input_path)
 
     # Mark as manual to skip validation (already validated when saved)
     original_source = data.get('source', 'llm')

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -17,6 +17,7 @@ from core.schemas import AnalyzeResult, AnalysisMetrics, UsageInfo
 from core import tracking
 from core.progress import ProgressReporter
 from core.utils import atomic_write_json
+from utilities.file_io import read_json
 
 # Import existing analysis machinery
 from utilities.llm_client import AnthropicClient, get_global_tracker
@@ -103,8 +104,7 @@ def run_analysis(
             print(f"[Analyze] Already complete: {results_path}", file=sys.stderr)
             print("[Analyze] Use --fresh to reanalyze all units from scratch.", file=sys.stderr)
 
-            with open(results_path) as f:
-                experiment = json.load(f)
+            experiment = read_json(results_path)
 
             metrics_data = experiment.get("metrics", {})
             metrics = AnalysisMetrics(
@@ -144,8 +144,7 @@ def run_analysis(
 
     # Load dataset
     print(f"[Analyze] Loading dataset: {dataset_path}", file=sys.stderr)
-    with open(dataset_path) as f:
-        dataset = json.load(f)
+    dataset = read_json(dataset_path)
 
     units = dataset.get("units", [])
 
@@ -177,8 +176,7 @@ def run_analysis(
     completed_ids = set()
     if checkpoint_path and os.path.exists(checkpoint_path):
         try:
-            with open(checkpoint_path) as f:
-                cp = json.load(f)
+            cp = read_json(checkpoint_path)
             results = cp.get("results", [])
             code_by_route = cp.get("code_by_route", {})
             completed_ids = {r["unit_id"] for r in results}

--- a/libs/openant-core/core/dynamic_tester.py
+++ b/libs/openant-core/core/dynamic_tester.py
@@ -5,7 +5,6 @@ Runs Docker-isolated exploit tests against confirmed vulnerabilities.
 Wraps ``utilities.dynamic_tester.run_dynamic_tests()``.
 """
 
-import json
 import os
 import shutil
 import sys

--- a/libs/openant-core/core/dynamic_tester.py
+++ b/libs/openant-core/core/dynamic_tester.py
@@ -12,6 +12,7 @@ import sys
 
 from core.schemas import DynamicTestStepResult, UsageInfo
 from core import tracking
+from utilities.file_io import read_json, write_json
 
 
 def run_tests(
@@ -53,8 +54,7 @@ def run_tests(
     tracking.reset_tracking()
 
     # Check how many findings to test
-    with open(pipeline_output_path) as f:
-        pipeline_data = json.load(f)
+    pipeline_data = read_json(pipeline_output_path)
 
     findings = pipeline_data.get("findings", [])
     testable = [
@@ -67,8 +67,7 @@ def run_tests(
 
     if not testable:
         results_path = os.path.join(output_dir, "dynamic_test_results.json")
-        with open(results_path, "w") as f:
-            json.dump({"findings_tested": 0, "results": []}, f, indent=2)
+        write_json(results_path, {"findings_tested": 0, "results": []})
 
         return DynamicTestStepResult(
             results_json_path=results_path,

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -5,6 +5,7 @@ Wraps utilities/context_enhancer.py, providing a path-based interface
 for both agentic and single-shot enhancement modes.
 """
 
+import json
 import os
 import sys
 

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -12,6 +12,7 @@ import sys
 from core.schemas import EnhanceResult, UsageInfo
 from core import tracking
 from core.progress import ProgressReporter
+from utilities.file_io import read_json
 
 
 def enhance_dataset(
@@ -58,8 +59,7 @@ def enhance_dataset(
             print("[Enhance] Use --fresh to reprocess all units from scratch.", file=sys.stderr)
 
             # Load the existing output to build the result
-            with open(output_path) as f:
-                enhanced = json.load(f)
+            enhanced = read_json(output_path)
 
             context_key = "agent_context" if mode == "agentic" else "llm_context"
             classifications = {}
@@ -94,8 +94,7 @@ def enhance_dataset(
 
     # Load dataset
     print(f"[Enhance] Loading dataset: {dataset_path}", file=sys.stderr)
-    with open(dataset_path) as f:
-        dataset = json.load(f)
+    dataset = read_json(dataset_path)
 
     units = dataset.get("units", [])
     print(f"[Enhance] Units to enhance: {len(units)}", file=sys.stderr)
@@ -104,8 +103,7 @@ def enhance_dataset(
     resumed_count = 0
     if checkpoint_path and os.path.exists(checkpoint_path):
         try:
-            with open(checkpoint_path) as f:
-                cp_data = json.load(f)
+            cp_data = read_json(checkpoint_path)
             for cp_unit in cp_data.get("units", []):
                 if cp_unit.get("agent_context") and not cp_unit["agent_context"].get("error"):
                     resumed_count += 1

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -5,7 +5,6 @@ Wraps utilities/context_enhancer.py, providing a path-based interface
 for both agentic and single-shot enhancement modes.
 """
 
-import json
 import os
 import sys
 

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -310,11 +310,9 @@ def _parse_javascript(repo_path: str, output_dir: str, processing_level: str, sk
     """
     print("[Parser] Running JavaScript parser...", file=sys.stderr)
 
-    parser_script = _CORE_ROOT / "parsers" / "javascript" / "test_pipeline.py"
-
     # Build command — analyzer-path now defaults to co-located file in the parser
     cmd = [
-        sys.executable, str(parser_script),
+        sys.executable, "-m", "parsers.javascript.test_pipeline",
         repo_path,
         "--output", output_dir,
         "--processing-level", processing_level,
@@ -367,10 +365,8 @@ def _parse_go(repo_path: str, output_dir: str, processing_level: str, skip_tests
     """
     print("[Parser] Running Go parser...", file=sys.stderr)
 
-    parser_script = _CORE_ROOT / "parsers" / "go" / "test_pipeline.py"
-
     cmd = [
-        sys.executable, str(parser_script),
+        sys.executable, "-m", "parsers.go.test_pipeline",
         repo_path,
         "--output", output_dir,
         "--processing-level", processing_level,
@@ -425,10 +421,8 @@ def _parse_c(repo_path: str, output_dir: str, processing_level: str, skip_tests:
     """
     print("[Parser] Running C/C++ parser...", file=sys.stderr)
 
-    parser_script = _CORE_ROOT / "parsers" / "c" / "test_pipeline.py"
-
     cmd = [
-        sys.executable, str(parser_script),
+        sys.executable, "-m", "parsers.c.test_pipeline",
         repo_path,
         "--output", output_dir,
         "--processing-level", processing_level,
@@ -484,10 +478,8 @@ def _parse_ruby(repo_path: str, output_dir: str, processing_level: str, skip_tes
     """
     print("[Parser] Running Ruby parser...", file=sys.stderr)
 
-    parser_script = _CORE_ROOT / "parsers" / "ruby" / "test_pipeline.py"
-
     cmd = [
-        sys.executable, str(parser_script),
+        sys.executable, "-m", "parsers.ruby.test_pipeline",
         repo_path,
         "--output", output_dir,
         "--processing-level", processing_level,
@@ -543,10 +535,8 @@ def _parse_php(repo_path: str, output_dir: str, processing_level: str, skip_test
     """
     print("[Parser] Running PHP parser...", file=sys.stderr)
 
-    parser_script = _CORE_ROOT / "parsers" / "php" / "test_pipeline.py"
-
     cmd = [
-        sys.executable, str(parser_script),
+        sys.executable, "-m", "parsers.php.test_pipeline",
         repo_path,
         "--output", output_dir,
         "--processing-level", processing_level,

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -27,7 +27,7 @@ _LANGUAGES_CONFIG = Path(__file__).parent.parent.parent.parent / "config" / "lan
 
 def _load_language_config() -> dict:
     """Load language detection config from the shared config/languages.json."""
-    return read_json(str(_LANGUAGES_CONFIG))
+    return read_json(_LANGUAGES_CONFIG)
 
 
 def detect_language(repo_path: str) -> str:

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 from core.schemas import ParseResult
+from utilities.file_io import read_json, write_json
 
 # Root of openant-core (where parsers/ lives)
 _CORE_ROOT = Path(__file__).parent.parent
@@ -26,8 +27,7 @@ _LANGUAGES_CONFIG = Path(__file__).parent.parent.parent.parent / "config" / "lan
 
 def _load_language_config() -> dict:
     """Load language detection config from the shared config/languages.json."""
-    with open(_LANGUAGES_CONFIG) as f:
-        return json.load(f)
+    return read_json(str(_LANGUAGES_CONFIG))
 
 
 def detect_language(repo_path: str) -> str:
@@ -177,8 +177,7 @@ def _apply_reachability_filter(
 
     print(f"\n[Reachability Filter] Filtering to {processing_level} units...", file=sys.stderr)
 
-    with open(call_graph_path, "r") as f:
-        call_graph_data = json.load(f)
+    call_graph_data = read_json(call_graph_path)
 
     functions = call_graph_data.get("functions", {})
     call_graph = call_graph_data.get("call_graph", {})
@@ -284,11 +283,8 @@ def _parse_python(repo_path: str, output_dir: str, processing_level: str, skip_t
         dataset = _apply_reachability_filter(dataset, output_dir, processing_level)
 
     # Write outputs
-    with open(dataset_path, "w") as f:
-        json.dump(dataset, f, indent=2)
-
-    with open(analyzer_output_path, "w") as f:
-        json.dump(analyzer_output, f, indent=2)
+    write_json(dataset_path, dataset)
+    write_json(analyzer_output_path, analyzer_output)
 
     units_count = len(dataset.get("units", []))
     print(f"  Python parser complete: {units_count} units", file=sys.stderr)
@@ -345,8 +341,7 @@ def _parse_javascript(repo_path: str, output_dir: str, processing_level: str, sk
     # Count units
     units_count = 0
     if os.path.exists(dataset_path):
-        with open(dataset_path) as f:
-            data = json.load(f)
+        data = read_json(dataset_path)
         units_count = len(data.get("units", []))
 
     print(f"  JavaScript parser complete: {units_count} units", file=sys.stderr)
@@ -402,8 +397,7 @@ def _parse_go(repo_path: str, output_dir: str, processing_level: str, skip_tests
     # Count units
     units_count = 0
     if os.path.exists(dataset_path):
-        with open(dataset_path) as f:
-            data = json.load(f)
+        data = read_json(dataset_path)
         units_count = len(data.get("units", []))
 
     print(f"  Go parser complete: {units_count} units", file=sys.stderr)
@@ -462,8 +456,7 @@ def _parse_c(repo_path: str, output_dir: str, processing_level: str, skip_tests:
     # Count units
     units_count = 0
     if os.path.exists(dataset_path):
-        with open(dataset_path) as f:
-            data = json.load(f)
+        data = read_json(dataset_path)
         units_count = len(data.get("units", []))
 
     print(f"  C/C++ parser complete: {units_count} units", file=sys.stderr)
@@ -522,8 +515,7 @@ def _parse_ruby(repo_path: str, output_dir: str, processing_level: str, skip_tes
     # Count units
     units_count = 0
     if os.path.exists(dataset_path):
-        with open(dataset_path) as f:
-            data = json.load(f)
+        data = read_json(dataset_path)
         units_count = len(data.get("units", []))
 
     print(f"  Ruby parser complete: {units_count} units", file=sys.stderr)
@@ -582,8 +574,7 @@ def _parse_php(repo_path: str, output_dir: str, processing_level: str, skip_test
     # Count units
     units_count = 0
     if os.path.exists(dataset_path):
-        with open(dataset_path) as f:
-            data = json.load(f)
+        data = read_json(dataset_path)
         units_count = len(data.get("units", []))
 
     print(f"  PHP parser complete: {units_count} units", file=sys.stderr)

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -11,7 +11,6 @@ into the ``pipeline_output.json`` format consumed by ``python -m report``
 and ``run_dynamic_tests()``.
 """
 
-import json
 import os
 import subprocess
 import sys

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from core.schemas import ReportResult
+from utilities.file_io import read_json, write_json
 
 # Root of openant-core
 _CORE_ROOT = Path(__file__).parent.parent
@@ -61,8 +62,7 @@ def build_pipeline_output(
     """
     print(f"[Report] Building pipeline_output.json...", file=sys.stderr)
 
-    with open(results_path) as f:
-        experiment = json.load(f)
+    experiment = read_json(results_path)
 
     all_results = experiment.get("results", [])
     code_by_route = experiment.get("code_by_route", {})
@@ -185,8 +185,7 @@ def build_pipeline_output(
     }
 
     os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-    with open(output_path, "w") as f:
-        json.dump(pipeline_output, f, indent=2, ensure_ascii=False)
+    write_json(output_path, pipeline_output, ensure_ascii=False)
 
     print(f"  pipeline_output.json: {len(findings_data)} findings", file=sys.stderr)
     print(f"  Written to {output_path}", file=sys.stderr)

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -31,6 +31,7 @@ from core.schemas import (
 )
 from core.step_report import step_context
 from core import tracking
+from utilities.file_io import read_json
 
 
 # Import app context generator (optional)
@@ -55,8 +56,7 @@ def _check_step_completed(output_dir: str, step: str) -> dict | None:
     """
     path = os.path.join(output_dir, f"{step}.report.json")
     try:
-        with open(path) as f:
-            report = json.load(f)
+        report = read_json(path)
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -72,8 +72,7 @@ def _check_step_completed(output_dir: str, step: str) -> dict | None:
         # Validate JSON for .json files
         if output_path.endswith(".json"):
             try:
-                with open(output_path) as f:
-                    json.load(f)
+                read_json(output_path)
             except (OSError, json.JSONDecodeError):
                 return None
 
@@ -772,8 +771,7 @@ def _load_step_report(output_dir: str, step: str) -> dict:
     """Load a step report JSON from disk. Returns empty dict on failure."""
     path = os.path.join(output_dir, f"{step}.report.json")
     try:
-        with open(path) as f:
-            return json.load(f)
+        return read_json(path)
     except Exception:
         return {"step": step, "status": "unknown"}
 
@@ -781,8 +779,7 @@ def _load_step_report(output_dir: str, step: str) -> dict:
 def _read_app_type(app_context_path: str) -> str | None:
     """Read application_type from an app context JSON file."""
     try:
-        with open(app_context_path) as f:
-            data = json.load(f)
+        data = read_json(app_context_path)
         return data.get("application_type")
     except Exception:
         return None

--- a/libs/openant-core/core/utils.py
+++ b/libs/openant-core/core/utils.py
@@ -16,7 +16,7 @@ def atomic_write_json(path: str, data: dict, indent: int = 2):
     os.makedirs(dir_name, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent)
         os.replace(tmp_path, path)
     except:

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -14,6 +14,7 @@ from core.schemas import VerifyResult, UsageInfo
 from core import tracking
 from core.progress import ProgressReporter
 from core.utils import atomic_write_json
+from utilities.file_io import read_json
 
 from utilities.llm_client import TokenTracker, get_global_tracker
 from utilities.finding_verifier import FindingVerifier
@@ -74,8 +75,7 @@ def run_verification(
             print(f"[Verify] Already complete: {verified_path}", file=sys.stderr)
             print("[Verify] Use --fresh to reverify all findings from scratch.", file=sys.stderr)
 
-            with open(verified_path) as f:
-                verified_data = json.load(f)
+            verified_data = read_json(verified_path)
 
             # Count from existing results
             agreed = 0
@@ -114,8 +114,7 @@ def run_verification(
 
     # Load Stage 1 results
     print(f"[Verify] Loading results: {results_path}", file=sys.stderr)
-    with open(results_path) as f:
-        experiment = json.load(f)
+    experiment = read_json(results_path)
 
     all_results = experiment.get("results", [])
     code_by_route = experiment.get("code_by_route", {})
@@ -180,8 +179,7 @@ def run_verification(
     resumed_count = 0
     if checkpoint_path and os.path.exists(checkpoint_path):
         try:
-            with open(checkpoint_path) as f:
-                cp = json.load(f)
+            cp = read_json(checkpoint_path)
             resumed_count = len(cp.get("completed_keys", []))
         except (json.JSONDecodeError, OSError):
             pass

--- a/libs/openant-core/experiment.py
+++ b/libs/openant-core/experiment.py
@@ -34,6 +34,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from utilities.file_io import read_json, write_json
 from utilities.llm_client import AnthropicClient, get_global_tracker
 from prompts.prompt_selector import get_analysis_prompt
 from prompts.vulnerability_analysis import get_system_prompt as get_stage1_system_prompt
@@ -211,8 +212,7 @@ def load_dataset(name: str, enhanced: bool = False) -> dict:
     if not path or not os.path.exists(path):
         raise ValueError(f"Dataset not found: {name} (enhanced={enhanced})")
 
-    with open(path, "r") as f:
-        return json.load(f)
+    return read_json(path)
 
 
 def load_ground_truth(name: str) -> dict:
@@ -221,8 +221,7 @@ def load_ground_truth(name: str) -> dict:
     if not path or not os.path.exists(path):
         return {}
 
-    with open(path, "r") as f:
-        return json.load(f)
+    return read_json(path)
 
 
 def get_ground_truth_verdict(ground_truth: dict, route_key: str) -> str:
@@ -1028,8 +1027,7 @@ def main():
         suffix = "" if args.no_enhanced else "_enhanced"
         output_path = f"experiment_{args.dataset}_{args.model}{suffix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
 
-    with open(output_path, "w") as f:
-        json.dump(experiment, f, indent=2)
+    write_json(output_path, experiment)
 
     print()
     print(f"Results saved to: {output_path}")

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -26,7 +26,6 @@ Example:
 
 import argparse
 import csv
-import json
 import os
 import sys
 

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -27,13 +27,20 @@ Example:
 import argparse
 import csv
 import json
+import os
 import sys
+
+# Ensure project root is on sys.path for utilities imports
+_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from utilities.file_io import read_json
 
 
 def load_json(path: str) -> dict:
     """Load JSON file."""
-    with open(path, 'r') as f:
-        return json.load(f)
+    return read_json(path)
 
 
 def extract_file(unit_id: str) -> str:

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -30,11 +30,6 @@ import json
 import os
 import sys
 
-# Ensure project root is on sys.path for utilities imports
-_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
-
 from utilities.file_io import read_json
 
 

--- a/libs/openant-core/generate_report.py
+++ b/libs/openant-core/generate_report.py
@@ -30,11 +30,6 @@ import os
 import sys
 from datetime import datetime
 
-# Ensure project root is on sys.path for utilities imports
-_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
-
 import anthropic
 from dotenv import load_dotenv
 from utilities.file_io import read_json

--- a/libs/openant-core/generate_report.py
+++ b/libs/openant-core/generate_report.py
@@ -27,10 +27,17 @@ import argparse
 import json
 import html
 import os
+import sys
 from datetime import datetime
+
+# Ensure project root is on sys.path for utilities imports
+_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
 
 import anthropic
 from dotenv import load_dotenv
+from utilities.file_io import read_json
 
 # Load environment variables from .env file
 load_dotenv()
@@ -42,8 +49,7 @@ MAX_TOKENS = 4096
 
 def load_json(path: str) -> dict:
     """Load JSON file."""
-    with open(path, 'r') as f:
-        return json.load(f)
+    return read_json(path)
 
 
 def extract_file(unit_id: str) -> str:

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -22,11 +22,6 @@ import os
 import sys
 import tempfile
 
-# Ensure project root is on sys.path for utilities imports
-_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
-
 from utilities.file_io import read_json
 
 

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -22,6 +22,13 @@ import os
 import sys
 import tempfile
 
+# Ensure project root is on sys.path for utilities imports
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from utilities.file_io import read_json
+
 
 def _output_json(data: dict):
     """Write JSON to stdout."""
@@ -326,8 +333,7 @@ def cmd_build_output(args):
         # Read back the generated file to extract findings count
         findings_count = 0
         try:
-            with open(path) as f:
-                pipeline_data = json.load(f)
+            pipeline_data = read_json(path)
             findings_count = len(pipeline_data.get("findings", []))
         except (OSError, json.JSONDecodeError):
             pass

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -32,10 +32,15 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_c as tsc
 import tree_sitter_cpp as tscpp
@@ -423,8 +428,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            extractor_output = json.load(f)
+        extractor_output = read_json(args.input_file)
 
         print(f"Processing {len(extractor_output.get('functions', {}))} functions...", file=sys.stderr)
 
@@ -444,7 +448,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Output written to: {args.output}", file=sys.stderr)
         else:

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -32,14 +32,11 @@ Output (JSON):
 """
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_c as tsc

--- a/libs/openant-core/parsers/c/function_extractor.py
+++ b/libs/openant-core/parsers/c/function_extractor.py
@@ -39,8 +39,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_c as tsc

--- a/libs/openant-core/parsers/c/function_extractor.py
+++ b/libs/openant-core/parsers/c/function_extractor.py
@@ -39,6 +39,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 import tree_sitter_c as tsc
 import tree_sitter_cpp as tscpp
 from tree_sitter import Language, Parser
@@ -575,8 +579,7 @@ Examples:
         extractor = FunctionExtractor(args.repo_path)
 
         if args.scan_file:
-            with open(args.scan_file) as f:
-                scan_result = json.load(f)
+            scan_result = read_json(args.scan_file)
             result = extractor.extract_from_scan(scan_result)
         else:
             result = extractor.extract_all()
@@ -584,7 +587,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Extraction complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total functions: {result['statistics']['total_functions']}", file=sys.stderr)

--- a/libs/openant-core/parsers/c/repository_scanner.py
+++ b/libs/openant-core/parsers/c/repository_scanner.py
@@ -31,8 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/c/repository_scanner.py
+++ b/libs/openant-core/parsers/c/repository_scanner.py
@@ -31,6 +31,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class RepositoryScanner:
     """
@@ -225,7 +229,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Scan complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total files found: {result['statistics']['total_files']}", file=sys.stderr)

--- a/libs/openant-core/parsers/c/test_pipeline.py
+++ b/libs/openant-core/parsers/c/test_pipeline.py
@@ -47,6 +47,7 @@ from typing import Set
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
+from utilities.file_io import read_json, write_json, open_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -139,8 +140,7 @@ class CPipelineTest:
 
             # Save scan results
             self.scan_results_file = os.path.join(self.output_dir, 'scan_results.json')
-            with open(self.scan_results_file, 'w') as f:
-                json.dump(scan_result, f, indent=2)
+            write_json(self.scan_results_file, scan_result)
 
             # Stage 2: Extract functions
             print("  [2/4] Extracting functions via tree-sitter...")
@@ -178,13 +178,11 @@ class CPipelineTest:
             print(f"         Avg upstream deps: {dataset['statistics']['avg_upstream']}")
 
             # Write dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             # Write analyzer output
             analyzer_output = generator.generate_analyzer_output()
-            with open(self.analyzer_output_file, 'w') as f:
-                json.dump(analyzer_output, f, indent=2)
+            write_json(self.analyzer_output_file, analyzer_output)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -242,8 +240,7 @@ class CPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
 
@@ -262,8 +259,7 @@ class CPipelineTest:
                 }
 
             # Build call graph from dataset unit metadata
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             call_graph = {}
             reverse_call_graph = {}
@@ -313,8 +309,7 @@ class CPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -443,8 +438,7 @@ class CPipelineTest:
                 }
                 return False
 
-            with open(sarif_output, 'r') as f:
-                sarif_data = json.load(f)
+            sarif_data = read_json(sarif_output)
 
             self.codeql_findings = []
 
@@ -555,8 +549,7 @@ class CPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Build mapping of file -> [(start_line, end_line, func_id)]
             file_functions = {}
@@ -605,8 +598,7 @@ class CPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -662,8 +654,7 @@ class CPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             enhancer = ContextEnhancer()
 
@@ -695,8 +686,7 @@ class CPipelineTest:
                     'data_flows_extracted': enhancer.stats['data_flows_extracted']
                 }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(enhanced, f, indent=2)
+            write_json(self.dataset_file, enhanced)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -740,8 +730,7 @@ class CPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -767,8 +756,7 @@ class CPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -908,22 +896,21 @@ class CPipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open(results_file, 'w') as f:
-            clean_results = {
-                'repository': self.results['repository'],
-                'test_time': self.results['test_time'],
-                'processing_level': self.results.get('processing_level', 'all'),
-                'success': self.results.get('success', False),
-                'stages': {}
+        clean_results = {
+            'repository': self.results['repository'],
+            'test_time': self.results['test_time'],
+            'processing_level': self.results.get('processing_level', 'all'),
+            'success': self.results.get('success', False),
+            'stages': {}
+        }
+        for stage_name, stage_result in self.results['stages'].items():
+            clean_results['stages'][stage_name] = {
+                'success': stage_result.get('success', False),
+                'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
+                'output_file': stage_result.get('output_file'),
+                'summary': stage_result.get('summary', {})
             }
-            for stage_name, stage_result in self.results['stages'].items():
-                clean_results['stages'][stage_name] = {
-                    'success': stage_result.get('success', False),
-                    'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
-                    'output_file': stage_result.get('output_file'),
-                    'summary': stage_result.get('summary', {})
-                }
-            json.dump(clean_results, f, indent=2)
+        write_json(results_file, clean_results)
 
         print(f"Results summary: {results_file}")
 

--- a/libs/openant-core/parsers/c/test_pipeline.py
+++ b/libs/openant-core/parsers/c/test_pipeline.py
@@ -45,7 +45,7 @@ from typing import Set
 
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
-from utilities.file_io import read_json, write_json, open_utf8
+from utilities.file_io import read_json, write_json, open_utf8, run_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -372,7 +372,7 @@ class CPipelineTest:
                 '--overwrite'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 create_db_cmd,
                 capture_output=True,
                 text=True,
@@ -403,7 +403,7 @@ class CPipelineTest:
                 f'codeql/{language}-queries:codeql-suites/{language}-security-extended.qls'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 analyze_cmd,
                 capture_output=True,
                 text=True,

--- a/libs/openant-core/parsers/c/test_pipeline.py
+++ b/libs/openant-core/parsers/c/test_pipeline.py
@@ -43,8 +43,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Set
 
-# Add parent directory to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
 from utilities.file_io import read_json, write_json, open_utf8

--- a/libs/openant-core/parsers/c/unit_generator.py
+++ b/libs/openant-core/parsers/c/unit_generator.py
@@ -24,10 +24,15 @@ Output (JSON):
 """
 
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 # File boundary marker for enhanced code (C-style comment, matching Go parser)
@@ -343,8 +348,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            call_graph_data = json.load(f)
+        call_graph_data = read_json(args.input_file)
 
         options = {
             'max_depth': args.depth,
@@ -373,7 +377,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"\nOutput written to: {args.output}", file=sys.stderr)
         else:
@@ -382,8 +386,7 @@ Examples:
         # Write analyzer output if requested
         if args.analyzer_output:
             analyzer = generator.generate_analyzer_output()
-            with open(args.analyzer_output, 'w') as f:
-                json.dump(analyzer, f, indent=2)
+            write_json(args.analyzer_output, analyzer)
             print(f"Analyzer output written to: {args.analyzer_output}", file=sys.stderr)
 
     except Exception as e:

--- a/libs/openant-core/parsers/c/unit_generator.py
+++ b/libs/openant-core/parsers/c/unit_generator.py
@@ -24,14 +24,11 @@ Output (JSON):
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -988,23 +988,22 @@ class GoPipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open_utf8(results_file, 'w') as f:
-            # Remove stdout/stderr from saved results (too verbose)
-            clean_results = {
-                'repository': self.results['repository'],
-                'test_time': self.results['test_time'],
-                'processing_level': self.results.get('processing_level', 'all'),
-                'success': self.results.get('success', False),
-                'stages': {}
+        # Remove stdout/stderr from saved results (too verbose)
+        clean_results = {
+            'repository': self.results['repository'],
+            'test_time': self.results['test_time'],
+            'processing_level': self.results.get('processing_level', 'all'),
+            'success': self.results.get('success', False),
+            'stages': {}
+        }
+        for stage_name, stage_result in self.results['stages'].items():
+            clean_results['stages'][stage_name] = {
+                'success': stage_result.get('success', False),
+                'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
+                'output_file': stage_result.get('output_file'),
+                'summary': stage_result.get('summary', {})
             }
-            for stage_name, stage_result in self.results['stages'].items():
-                clean_results['stages'][stage_name] = {
-                    'success': stage_result.get('success', False),
-                    'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
-                    'output_file': stage_result.get('output_file'),
-                    'summary': stage_result.get('summary', {})
-                }
-            json.dump(clean_results, f, indent=2)
+        write_json(results_file, clean_results)
 
         print(f"Results summary: {results_file}")
 

--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -43,8 +43,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Set
 
-# Add parent directory to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
 from utilities.file_io import open_utf8, read_json, write_json, run_utf8

--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -47,6 +47,7 @@ from typing import Set
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
+from utilities.file_io import open_utf8, read_json, write_json, run_utf8
 
 
 class ProcessingLevel(Enum):
@@ -115,7 +116,7 @@ class GoPipelineTest:
         if not os.path.exists(self.go_parser):
             print("Building Go parser...")
             go_parser_dir = os.path.join(self.parser_dir, 'go_parser')
-            result = subprocess.run(
+            result = run_utf8(
                 ['go', 'build', '-o', 'go_parser', '.'],
                 cwd=go_parser_dir,
                 capture_output=True,
@@ -140,7 +141,7 @@ class GoPipelineTest:
         start_time = datetime.now()
 
         try:
-            result = subprocess.run(
+            result = run_utf8(
                 command,
                 capture_output=True,
                 text=True,
@@ -168,8 +169,7 @@ class GoPipelineTest:
 
                 # Load and summarize output
                 if os.path.exists(output_file):
-                    with open(output_file, 'r') as f:
-                        data = json.load(f)
+                    data = read_json(output_file)
                     stage_result['summary'] = self._summarize_output(name, data)
             else:
                 print(f"FAIL Failed (exit code {result.returncode})")
@@ -244,11 +244,9 @@ class GoPipelineTest:
         # Post-process: apply dataset name if specified (Go binary doesn't support --name)
         if result.get('success', False) and self.dataset_name and os.path.exists(self.dataset_file):
             try:
-                with open(self.dataset_file, 'r') as f:
-                    dataset = json.load(f)
+                dataset = read_json(self.dataset_file)
                 dataset['name'] = self.dataset_name
-                with open(self.dataset_file, 'w') as f:
-                    json.dump(dataset, f, indent=2)
+                write_json(self.dataset_file, dataset)
             except Exception as e:
                 print(f"Warning: Could not apply dataset name: {e}")
 
@@ -282,8 +280,7 @@ class GoPipelineTest:
 
         try:
             # Load analyzer output for call graph
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
 
@@ -304,8 +301,7 @@ class GoPipelineTest:
                 }
 
             # Load call graph from dataset (go_parser puts it in statistics)
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Build call graph from unit metadata
             call_graph = {}
@@ -359,8 +355,7 @@ class GoPipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -434,7 +429,7 @@ class GoPipelineTest:
                 '--overwrite'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 create_db_cmd,
                 capture_output=True,
                 text=True,
@@ -465,7 +460,7 @@ class GoPipelineTest:
                 f'codeql/{language}-queries:codeql-suites/{language}-security-extended.qls'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 analyze_cmd,
                 capture_output=True,
                 text=True,
@@ -498,8 +493,7 @@ class GoPipelineTest:
                 }
                 return False
 
-            with open(sarif_output, 'r') as f:
-                sarif_data = json.load(f)
+            sarif_data = read_json(sarif_output)
 
             # Extract findings and map to file:line
             self.codeql_findings = []
@@ -620,8 +614,7 @@ class GoPipelineTest:
 
         try:
             # Load dataset to get function line ranges
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Build mapping of file -> [(start_line, end_line, func_id)]
             file_functions = {}
@@ -675,8 +668,7 @@ class GoPipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -733,8 +725,7 @@ class GoPipelineTest:
 
         try:
             # Load dataset
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Enhance with LLM
             enhancer = ContextEnhancer()
@@ -771,8 +762,7 @@ class GoPipelineTest:
                 }
 
             # Write back
-            with open(self.dataset_file, 'w') as f:
-                json.dump(enhanced, f, indent=2)
+            write_json(self.dataset_file, enhanced)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -824,8 +814,7 @@ class GoPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -854,8 +843,7 @@ class GoPipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -1002,7 +990,7 @@ class GoPipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open(results_file, 'w') as f:
+        with open_utf8(results_file, 'w') as f:
             # Remove stdout/stderr from saved results (too verbose)
             clean_results = {
                 'repository': self.results['repository'],

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -46,6 +46,7 @@ from typing import Set, Tuple
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
+from utilities.file_io import open_utf8, read_json, write_json, run_utf8
 
 
 class ProcessingLevel(Enum):
@@ -126,7 +127,7 @@ class PipelineTest:
         start_time = datetime.now()
 
         try:
-            result = subprocess.run(
+            result = run_utf8(
                 command,
                 capture_output=True,
                 text=True,
@@ -154,8 +155,7 @@ class PipelineTest:
 
                 # Load and summarize output
                 if os.path.exists(output_file):
-                    with open(output_file, 'r') as f:
-                        data = json.load(f)
+                    data = read_json(output_file)
                     stage_result['summary'] = self._summarize_output(name, data)
             else:
                 print(f"FAIL Failed (exit code {result.returncode})")
@@ -242,8 +242,7 @@ class PipelineTest:
 
         # If no specific files, use ALL files from scan results
         if not files and self.scan_results_file and os.path.exists(self.scan_results_file):
-            with open(self.scan_results_file, 'r') as f:
-                scan_data = json.load(f)
+            scan_data = read_json(self.scan_results_file)
             files = [f['path'] for f in scan_data.get('files', [])]
 
         if not files:
@@ -252,7 +251,7 @@ class PipelineTest:
 
         # Write file list to a temporary file to avoid command-line length limits
         file_list_path = os.path.join(self.output_dir, 'file_list.txt')
-        with open(file_list_path, 'w') as f:
+        with open_utf8(file_list_path, 'w') as f:
             for file_path in files:
                 # Convert relative path to absolute
                 if not os.path.isabs(file_path):
@@ -289,7 +288,7 @@ class PipelineTest:
         start_time = datetime.now()
 
         try:
-            result = subprocess.run(
+            result = run_utf8(
                 command,
                 capture_output=True,
                 text=True,
@@ -300,7 +299,7 @@ class PipelineTest:
 
             if result.returncode == 0:
                 # Write stdout to output file
-                with open(output_file, 'w') as f:
+                with open_utf8(output_file, 'w') as f:
                     f.write(result.stdout)
 
                 print(f"OK Success ({elapsed:.2f}s)")
@@ -313,7 +312,7 @@ class PipelineTest:
 
                 # Load and summarize output
                 if os.path.exists(output_file):
-                    with open(output_file, 'r') as f:
+                    with open(output_file, 'r', encoding='utf-8') as f:
                         data = json.load(f)
                     summary = self._summarize_output(name, data)
                 else:
@@ -391,8 +390,7 @@ class PipelineTest:
 
         try:
             # Load dataset
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Enhance with LLM
             enhancer = ContextEnhancer()
@@ -432,8 +430,7 @@ class PipelineTest:
                 }
 
             # Write back
-            with open(self.dataset_file, 'w') as f:
-                json.dump(enhanced, f, indent=2)
+            write_json(self.dataset_file, enhanced)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -490,8 +487,7 @@ class PipelineTest:
 
         try:
             # Load analyzer output for call graph
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
             call_graph = analyzer.get("call_graph", analyzer.get("callGraph", {}))
@@ -510,8 +506,7 @@ class PipelineTest:
             self.reachable_units = reachability.get_all_reachable()
 
             # Load and filter dataset
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -539,8 +534,7 @@ class PipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -590,8 +584,7 @@ class PipelineTest:
             return "javascript"  # Default
 
         try:
-            with open(self.scan_results_file, 'r') as f:
-                scan_data = json.load(f)
+            scan_data = read_json(self.scan_results_file)
 
             stats = scan_data.get('statistics', {})
             by_extension = stats.get('byExtension', {})
@@ -642,7 +635,7 @@ class PipelineTest:
                 '--overwrite'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 create_db_cmd,
                 capture_output=True,
                 text=True,
@@ -673,7 +666,7 @@ class PipelineTest:
                 f'codeql/{language}-queries:codeql-suites/{language}-security-extended.qls'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 analyze_cmd,
                 capture_output=True,
                 text=True,
@@ -706,8 +699,7 @@ class PipelineTest:
                 }
                 return False
 
-            with open(sarif_output, 'r') as f:
-                sarif_data = json.load(f)
+            sarif_data = read_json(sarif_output)
 
             # Extract findings and map to file:line
             self.codeql_findings = []
@@ -830,8 +822,7 @@ class PipelineTest:
 
         try:
             # Load analyzer output to get function line ranges
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
 
@@ -869,8 +860,7 @@ class PipelineTest:
                             self.codeql_flagged_units.add(func_id)
 
             # Load and filter dataset
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -891,8 +881,7 @@ class PipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -955,8 +944,7 @@ class PipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -985,8 +973,7 @@ class PipelineTest:
             }
 
             # Write filtered dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -1143,7 +1130,7 @@ class PipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open(results_file, 'w') as f:
+        with open_utf8(results_file, 'w') as f:
             # Remove stdout/stderr from saved results (too verbose)
             clean_results = {
                 'repository': self.results['repository'],

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -310,8 +310,7 @@ class PipelineTest:
 
                 # Load and summarize output
                 if os.path.exists(output_file):
-                    with open(output_file, 'r', encoding='utf-8') as f:
-                        data = json.load(f)
+                    data = read_json(output_file)
                     summary = self._summarize_output(name, data)
                 else:
                     summary = {}
@@ -1128,23 +1127,22 @@ class PipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open_utf8(results_file, 'w') as f:
-            # Remove stdout/stderr from saved results (too verbose)
-            clean_results = {
-                'repository': self.results['repository'],
-                'test_time': self.results['test_time'],
-                'processing_level': self.results.get('processing_level', 'all'),
-                'success': self.results.get('success', False),
-                'stages': {}
+        # Remove stdout/stderr from saved results (too verbose)
+        clean_results = {
+            'repository': self.results['repository'],
+            'test_time': self.results['test_time'],
+            'processing_level': self.results.get('processing_level', 'all'),
+            'success': self.results.get('success', False),
+            'stages': {}
+        }
+        for stage_name, stage_result in self.results['stages'].items():
+            clean_results['stages'][stage_name] = {
+                'success': stage_result.get('success', False),
+                'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
+                'output_file': stage_result.get('output_file'),
+                'summary': stage_result.get('summary', {})
             }
-            for stage_name, stage_result in self.results['stages'].items():
-                clean_results['stages'][stage_name] = {
-                    'success': stage_result.get('success', False),
-                    'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
-                    'output_file': stage_result.get('output_file'),
-                    'summary': stage_result.get('summary', {})
-                }
-            json.dump(clean_results, f, indent=2)
+        write_json(results_file, clean_results)
 
         print(f"Results summary: {results_file}")
 

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -42,8 +42,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Set, Tuple
 
-# Add parent directory to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
 from utilities.file_io import open_utf8, read_json, write_json, run_utf8

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -32,10 +32,15 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_php as ts_php
 from tree_sitter import Language, Parser
@@ -482,8 +487,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            extractor_output = json.load(f)
+        extractor_output = read_json(args.input_file)
 
         print(f"Processing {len(extractor_output.get('functions', {}))} functions...", file=sys.stderr)
 
@@ -503,7 +507,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Output written to: {args.output}", file=sys.stderr)
         else:

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -32,14 +32,11 @@ Output (JSON):
 """
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_php as ts_php

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -34,14 +34,11 @@ Output (JSON):
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_php as ts_php

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -40,6 +40,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 import tree_sitter_php as ts_php
 from tree_sitter import Language, Parser
 
@@ -547,8 +551,7 @@ Examples:
         extractor = FunctionExtractor(args.repo_path)
 
         if args.scan_file:
-            with open(args.scan_file) as f:
-                scan_result = json.load(f)
+            scan_result = read_json(args.scan_file)
             result = extractor.extract_from_scan(scan_result)
         else:
             result = extractor.extract_all()
@@ -556,7 +559,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Extraction complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total functions: {result['statistics']['total_functions']}", file=sys.stderr)

--- a/libs/openant-core/parsers/php/repository_scanner.py
+++ b/libs/openant-core/parsers/php/repository_scanner.py
@@ -31,6 +31,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class RepositoryScanner:
     """
@@ -236,7 +240,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Scan complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total files found: {result['statistics']['total_files']}", file=sys.stderr)

--- a/libs/openant-core/parsers/php/repository_scanner.py
+++ b/libs/openant-core/parsers/php/repository_scanner.py
@@ -31,8 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/php/test_pipeline.py
+++ b/libs/openant-core/parsers/php/test_pipeline.py
@@ -45,7 +45,7 @@ from typing import Set
 
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
-from utilities.file_io import read_json, write_json, open_utf8
+from utilities.file_io import read_json, write_json, open_utf8, run_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -372,7 +372,7 @@ class PHPPipelineTest:
                 '--overwrite'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 create_db_cmd,
                 capture_output=True,
                 text=True,
@@ -403,7 +403,7 @@ class PHPPipelineTest:
                 f'codeql/{language}-queries:codeql-suites/{language}-security-extended.qls'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 analyze_cmd,
                 capture_output=True,
                 text=True,

--- a/libs/openant-core/parsers/php/test_pipeline.py
+++ b/libs/openant-core/parsers/php/test_pipeline.py
@@ -43,8 +43,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Set
 
-# Add parent directory to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
 from utilities.file_io import read_json, write_json, open_utf8

--- a/libs/openant-core/parsers/php/test_pipeline.py
+++ b/libs/openant-core/parsers/php/test_pipeline.py
@@ -47,6 +47,7 @@ from typing import Set
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
+from utilities.file_io import read_json, write_json, open_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -139,8 +140,7 @@ class PHPPipelineTest:
 
             # Save scan results
             self.scan_results_file = os.path.join(self.output_dir, 'scan_results.json')
-            with open(self.scan_results_file, 'w') as f:
-                json.dump(scan_result, f, indent=2)
+            write_json(self.scan_results_file, scan_result)
 
             # Stage 2: Extract functions
             print("  [2/4] Extracting functions via tree-sitter...")
@@ -178,13 +178,11 @@ class PHPPipelineTest:
             print(f"         Avg upstream deps: {dataset['statistics']['avg_upstream']}")
 
             # Write dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             # Write analyzer output
             analyzer_output = generator.generate_analyzer_output()
-            with open(self.analyzer_output_file, 'w') as f:
-                json.dump(analyzer_output, f, indent=2)
+            write_json(self.analyzer_output_file, analyzer_output)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -242,8 +240,7 @@ class PHPPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
 
@@ -262,8 +259,7 @@ class PHPPipelineTest:
                 }
 
             # Build call graph from dataset unit metadata
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             call_graph = {}
             reverse_call_graph = {}
@@ -313,8 +309,7 @@ class PHPPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -443,8 +438,7 @@ class PHPPipelineTest:
                 }
                 return False
 
-            with open(sarif_output, 'r') as f:
-                sarif_data = json.load(f)
+            sarif_data = read_json(sarif_output)
 
             self.codeql_findings = []
 
@@ -555,8 +549,7 @@ class PHPPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Build mapping of file -> [(start_line, end_line, func_id)]
             file_functions = {}
@@ -605,8 +598,7 @@ class PHPPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -662,8 +654,7 @@ class PHPPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             enhancer = ContextEnhancer()
 
@@ -695,8 +686,7 @@ class PHPPipelineTest:
                     'data_flows_extracted': enhancer.stats['data_flows_extracted']
                 }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(enhanced, f, indent=2)
+            write_json(self.dataset_file, enhanced)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -740,8 +730,7 @@ class PHPPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -767,8 +756,7 @@ class PHPPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -908,22 +896,21 @@ class PHPPipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open(results_file, 'w') as f:
-            clean_results = {
-                'repository': self.results['repository'],
-                'test_time': self.results['test_time'],
-                'processing_level': self.results.get('processing_level', 'all'),
-                'success': self.results.get('success', False),
-                'stages': {}
+        clean_results = {
+            'repository': self.results['repository'],
+            'test_time': self.results['test_time'],
+            'processing_level': self.results.get('processing_level', 'all'),
+            'success': self.results.get('success', False),
+            'stages': {}
+        }
+        for stage_name, stage_result in self.results['stages'].items():
+            clean_results['stages'][stage_name] = {
+                'success': stage_result.get('success', False),
+                'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
+                'output_file': stage_result.get('output_file'),
+                'summary': stage_result.get('summary', {})
             }
-            for stage_name, stage_result in self.results['stages'].items():
-                clean_results['stages'][stage_name] = {
-                    'success': stage_result.get('success', False),
-                    'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
-                    'output_file': stage_result.get('output_file'),
-                    'summary': stage_result.get('summary', {})
-                }
-            json.dump(clean_results, f, indent=2)
+        write_json(results_file, clean_results)
 
         print(f"Results summary: {results_file}")
 

--- a/libs/openant-core/parsers/php/unit_generator.py
+++ b/libs/openant-core/parsers/php/unit_generator.py
@@ -24,14 +24,11 @@ Output (JSON):
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/php/unit_generator.py
+++ b/libs/openant-core/parsers/php/unit_generator.py
@@ -24,10 +24,15 @@ Output (JSON):
 """
 
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 # File boundary marker for enhanced code (PHP uses // comments)
@@ -344,8 +349,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            call_graph_data = json.load(f)
+        call_graph_data = read_json(args.input_file)
 
         options = {
             'max_depth': args.depth,
@@ -374,7 +378,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"\nOutput written to: {args.output}", file=sys.stderr)
         else:
@@ -383,8 +387,7 @@ Examples:
         # Write analyzer output if requested
         if args.analyzer_output:
             analyzer = generator.generate_analyzer_output()
-            with open(args.analyzer_output, 'w') as f:
-                json.dump(analyzer, f, indent=2)
+            write_json(args.analyzer_output, analyzer)
             print(f"Analyzer output written to: {args.analyzer_output}", file=sys.stderr)
 
     except Exception as e:

--- a/libs/openant-core/parsers/python/ast_parser.py
+++ b/libs/openant-core/parsers/python/ast_parser.py
@@ -18,6 +18,10 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class PythonRouteParser:
     """Parse Python web frameworks to extract routes and handlers."""
@@ -461,8 +465,7 @@ def main():
     result = parser.parse()
 
     if output_file:
-        with open(output_file, 'w') as f:
-            json.dump(result, f, indent=2)
+        write_json(output_file, result)
         print(f"Output written to {output_file}")
     else:
         print(json.dumps(result, indent=2))

--- a/libs/openant-core/parsers/python/ast_parser.py
+++ b/libs/openant-core/parsers/python/ast_parser.py
@@ -12,14 +12,11 @@ Outputs dataset.json in the same format as the JavaScript parser.
 
 import ast
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -33,14 +33,11 @@ Output (JSON):
 
 import ast
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -33,10 +33,15 @@ Output (JSON):
 
 import ast
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 class CallGraphBuilder:
@@ -491,8 +496,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            extractor_output = json.load(f)
+        extractor_output = read_json(args.input_file)
 
         print(f"Processing {len(extractor_output.get('functions', {}))} functions...", file=sys.stderr)
 
@@ -512,7 +516,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Output written to: {args.output}", file=sys.stderr)
         else:

--- a/libs/openant-core/parsers/python/dataset_enhancer.py
+++ b/libs/openant-core/parsers/python/dataset_enhancer.py
@@ -14,6 +14,10 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class PythonDependencyResolver:
     """Resolve and collect Python code dependencies."""
@@ -226,8 +230,7 @@ class PythonDependencyResolver:
 
 def enhance_dataset(dataset_path: str, repo_path: str, output_path: str = None):
     """Enhance a dataset with resolved dependencies."""
-    with open(dataset_path, 'r') as f:
-        dataset = json.load(f)
+    dataset = read_json(dataset_path)
 
     resolver = PythonDependencyResolver(repo_path)
 
@@ -263,8 +266,7 @@ def enhance_dataset(dataset_path: str, repo_path: str, output_path: str = None):
     dataset['enhanced'] = True
 
     if output_path:
-        with open(output_path, 'w') as f:
-            json.dump(dataset, f, indent=2)
+        write_json(output_path, dataset)
         print(f"Enhanced dataset written to {output_path}")
     else:
         print(json.dumps(dataset, indent=2))

--- a/libs/openant-core/parsers/python/dataset_enhancer.py
+++ b/libs/openant-core/parsers/python/dataset_enhancer.py
@@ -8,14 +8,11 @@ function calls and gathering related code.
 
 import ast
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -65,6 +65,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class FunctionExtractor:
     """
@@ -596,8 +600,7 @@ Examples:
         extractor = FunctionExtractor(args.repo_path)
 
         if args.scan_file:
-            with open(args.scan_file) as f:
-                scan_result = json.load(f)
+            scan_result = read_json(args.scan_file)
             result = extractor.extract_from_scan(scan_result)
         else:
             result = extractor.extract_all()
@@ -605,7 +608,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Extraction complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total functions: {result['statistics']['total_functions']}", file=sys.stderr)

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -59,14 +59,11 @@ Output (JSON):
 
 import ast
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/parse_repository.py
+++ b/libs/openant-core/parsers/python/parse_repository.py
@@ -44,13 +44,10 @@ See Also:
 
 import argparse
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 from repository_scanner import RepositoryScanner

--- a/libs/openant-core/parsers/python/parse_repository.py
+++ b/libs/openant-core/parsers/python/parse_repository.py
@@ -44,9 +44,14 @@ See Also:
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 from repository_scanner import RepositoryScanner
 from function_extractor import FunctionExtractor
@@ -138,8 +143,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         scan_file = Path(output_dir) / 'scan_result.json'
-        with open(scan_file, 'w') as f:
-            json.dump(scan_result, f, indent=2)
+        write_json(str(scan_file), scan_result)
         print(f"  Saved: {scan_file}", file=sys.stderr)
 
     # Phase 2: Extract functions
@@ -154,8 +158,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         extract_file = Path(output_dir) / 'functions.json'
-        with open(extract_file, 'w') as f:
-            json.dump(extractor_result, f, indent=2)
+        write_json(str(extract_file), extractor_result)
         print(f"  Saved: {extract_file}", file=sys.stderr)
 
     # Phase 3: Build call graph
@@ -171,8 +174,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         graph_file = Path(output_dir) / 'call_graph.json'
-        with open(graph_file, 'w') as f:
-            json.dump(call_graph_result, f, indent=2)
+        write_json(str(graph_file), call_graph_result)
         print(f"  Saved: {graph_file}", file=sys.stderr)
 
     # Phase 4: Generate units
@@ -199,8 +201,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         analyzer_file = Path(output_dir) / 'analyzer_output.json'
-        with open(analyzer_file, 'w') as f:
-            json.dump(analyzer_output, f, indent=2)
+        write_json(str(analyzer_file), analyzer_output)
         print(f"  Saved: {analyzer_file}", file=sys.stderr)
 
     print(f"\n" + "=" * 60, file=sys.stderr)
@@ -253,7 +254,7 @@ Examples:
         # Save dataset
         dataset_json = json.dumps(dataset, indent=2)
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(dataset_json)
             print(f"\nDataset written to: {args.output}", file=sys.stderr)
         else:
@@ -261,8 +262,7 @@ Examples:
 
         # Save analyzer output if requested
         if args.analyzer_output:
-            with open(args.analyzer_output, 'w') as f:
-                json.dump(analyzer_output, f, indent=2)
+            write_json(args.analyzer_output, analyzer_output)
             print(f"Analyzer output written to: {args.analyzer_output}", file=sys.stderr)
 
     except Exception as e:

--- a/libs/openant-core/parsers/python/parse_repository.py
+++ b/libs/openant-core/parsers/python/parse_repository.py
@@ -140,7 +140,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         scan_file = Path(output_dir) / 'scan_result.json'
-        write_json(str(scan_file), scan_result)
+        write_json(scan_file, scan_result)
         print(f"  Saved: {scan_file}", file=sys.stderr)
 
     # Phase 2: Extract functions
@@ -155,7 +155,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         extract_file = Path(output_dir) / 'functions.json'
-        write_json(str(extract_file), extractor_result)
+        write_json(extract_file, extractor_result)
         print(f"  Saved: {extract_file}", file=sys.stderr)
 
     # Phase 3: Build call graph
@@ -171,7 +171,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         graph_file = Path(output_dir) / 'call_graph.json'
-        write_json(str(graph_file), call_graph_result)
+        write_json(graph_file, call_graph_result)
         print(f"  Saved: {graph_file}", file=sys.stderr)
 
     # Phase 4: Generate units
@@ -198,7 +198,7 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
 
     if output_dir:
         analyzer_file = Path(output_dir) / 'analyzer_output.json'
-        write_json(str(analyzer_file), analyzer_output)
+        write_json(analyzer_file, analyzer_output)
         print(f"  Saved: {analyzer_file}", file=sys.stderr)
 
     print(f"\n" + "=" * 60, file=sys.stderr)

--- a/libs/openant-core/parsers/python/repository_scanner.py
+++ b/libs/openant-core/parsers/python/repository_scanner.py
@@ -31,8 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/repository_scanner.py
+++ b/libs/openant-core/parsers/python/repository_scanner.py
@@ -31,6 +31,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class RepositoryScanner:
     """
@@ -289,7 +293,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Scan complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total files found: {result['statistics']['total_files']}", file=sys.stderr)

--- a/libs/openant-core/parsers/python/unit_generator.py
+++ b/libs/openant-core/parsers/python/unit_generator.py
@@ -49,14 +49,11 @@ Output (JSON):
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/python/unit_generator.py
+++ b/libs/openant-core/parsers/python/unit_generator.py
@@ -49,10 +49,15 @@ Output (JSON):
 """
 
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 # File boundary marker for enhanced code
@@ -400,8 +405,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            call_graph_data = json.load(f)
+        call_graph_data = read_json(args.input_file)
 
         options = {
             'max_depth': args.depth,
@@ -430,7 +434,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"\nOutput written to: {args.output}", file=sys.stderr)
         else:

--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -32,10 +32,15 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_ruby as ts_ruby
 from tree_sitter import Language, Parser
@@ -441,8 +446,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            extractor_output = json.load(f)
+        extractor_output = read_json(args.input_file)
 
         print(f"Processing {len(extractor_output.get('functions', {}))} functions...", file=sys.stderr)
 
@@ -462,7 +466,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Output written to: {args.output}", file=sys.stderr)
         else:

--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -32,14 +32,11 @@ Output (JSON):
 """
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_ruby as ts_ruby

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -34,14 +34,11 @@ Output (JSON):
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 import tree_sitter_ruby as ts_ruby

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -40,6 +40,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 import tree_sitter_ruby as ts_ruby
 from tree_sitter import Language, Parser
 
@@ -444,8 +448,7 @@ Examples:
         extractor = FunctionExtractor(args.repo_path)
 
         if args.scan_file:
-            with open(args.scan_file) as f:
-                scan_result = json.load(f)
+            scan_result = read_json(args.scan_file)
             result = extractor.extract_from_scan(scan_result)
         else:
             result = extractor.extract_all()
@@ -453,7 +456,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Extraction complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total functions: {result['statistics']['total_functions']}", file=sys.stderr)

--- a/libs/openant-core/parsers/ruby/repository_scanner.py
+++ b/libs/openant-core/parsers/ruby/repository_scanner.py
@@ -31,6 +31,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+# Add project root to path for utilities import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from utilities.file_io import read_json, write_json, open_utf8
+
 
 class RepositoryScanner:
     """
@@ -240,7 +244,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
+            with open_utf8(args.output, 'w') as f:
                 f.write(output)
             print(f"Scan complete. Results written to: {args.output}", file=sys.stderr)
             print(f"Total files found: {result['statistics']['total_files']}", file=sys.stderr)

--- a/libs/openant-core/parsers/ruby/repository_scanner.py
+++ b/libs/openant-core/parsers/ruby/repository_scanner.py
@@ -31,8 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-# Add project root to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.file_io import read_json, write_json, open_utf8
 
 

--- a/libs/openant-core/parsers/ruby/test_pipeline.py
+++ b/libs/openant-core/parsers/ruby/test_pipeline.py
@@ -45,7 +45,7 @@ from typing import Set
 
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
-from utilities.file_io import read_json, write_json, open_utf8
+from utilities.file_io import read_json, write_json, open_utf8, run_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -372,7 +372,7 @@ class RubyPipelineTest:
                 '--overwrite'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 create_db_cmd,
                 capture_output=True,
                 text=True,
@@ -403,7 +403,7 @@ class RubyPipelineTest:
                 f'codeql/{language}-queries:codeql-suites/{language}-security-extended.qls'
             ]
 
-            result = subprocess.run(
+            result = run_utf8(
                 analyze_cmd,
                 capture_output=True,
                 text=True,

--- a/libs/openant-core/parsers/ruby/test_pipeline.py
+++ b/libs/openant-core/parsers/ruby/test_pipeline.py
@@ -47,6 +47,7 @@ from typing import Set
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
+from utilities.file_io import read_json, write_json, open_utf8
 
 # Local imports
 from repository_scanner import RepositoryScanner
@@ -139,8 +140,7 @@ class RubyPipelineTest:
 
             # Save scan results
             self.scan_results_file = os.path.join(self.output_dir, 'scan_results.json')
-            with open(self.scan_results_file, 'w') as f:
-                json.dump(scan_result, f, indent=2)
+            write_json(self.scan_results_file, scan_result)
 
             # Stage 2: Extract functions
             print("  [2/4] Extracting functions via tree-sitter...")
@@ -178,13 +178,11 @@ class RubyPipelineTest:
             print(f"         Avg upstream deps: {dataset['statistics']['avg_upstream']}")
 
             # Write dataset
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             # Write analyzer output
             analyzer_output = generator.generate_analyzer_output()
-            with open(self.analyzer_output_file, 'w') as f:
-                json.dump(analyzer_output, f, indent=2)
+            write_json(self.analyzer_output_file, analyzer_output)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -242,8 +240,7 @@ class RubyPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.analyzer_output_file, 'r') as f:
-                analyzer = json.load(f)
+            analyzer = read_json(self.analyzer_output_file)
 
             functions = analyzer.get("functions", {})
 
@@ -262,8 +259,7 @@ class RubyPipelineTest:
                 }
 
             # Build call graph from dataset unit metadata
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             call_graph = {}
             reverse_call_graph = {}
@@ -313,8 +309,7 @@ class RubyPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -443,8 +438,7 @@ class RubyPipelineTest:
                 }
                 return False
 
-            with open(sarif_output, 'r') as f:
-                sarif_data = json.load(f)
+            sarif_data = read_json(sarif_output)
 
             self.codeql_findings = []
 
@@ -555,8 +549,7 @@ class RubyPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             # Build mapping of file -> [(start_line, end_line, func_id)]
             file_functions = {}
@@ -605,8 +598,7 @@ class RubyPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -662,8 +654,7 @@ class RubyPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             enhancer = ContextEnhancer()
 
@@ -695,8 +686,7 @@ class RubyPipelineTest:
                     'data_flows_extracted': enhancer.stats['data_flows_extracted']
                 }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(enhanced, f, indent=2)
+            write_json(self.dataset_file, enhanced)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -740,8 +730,7 @@ class RubyPipelineTest:
         start_time = datetime.now()
 
         try:
-            with open(self.dataset_file, 'r') as f:
-                dataset = json.load(f)
+            dataset = read_json(self.dataset_file)
 
             units = dataset.get("units", [])
             original_count = len(units)
@@ -767,8 +756,7 @@ class RubyPipelineTest:
                 "reduction_percentage": round((1 - len(filtered_units) / original_count) * 100, 1) if original_count > 0 else 0
             }
 
-            with open(self.dataset_file, 'w') as f:
-                json.dump(dataset, f, indent=2)
+            write_json(self.dataset_file, dataset)
 
             elapsed = (datetime.now() - start_time).total_seconds()
 
@@ -908,22 +896,21 @@ class RubyPipelineTest:
 
         # Save results summary
         results_file = os.path.join(self.output_dir, 'pipeline_results.json')
-        with open(results_file, 'w') as f:
-            clean_results = {
-                'repository': self.results['repository'],
-                'test_time': self.results['test_time'],
-                'processing_level': self.results.get('processing_level', 'all'),
-                'success': self.results.get('success', False),
-                'stages': {}
+        clean_results = {
+            'repository': self.results['repository'],
+            'test_time': self.results['test_time'],
+            'processing_level': self.results.get('processing_level', 'all'),
+            'success': self.results.get('success', False),
+            'stages': {}
+        }
+        for stage_name, stage_result in self.results['stages'].items():
+            clean_results['stages'][stage_name] = {
+                'success': stage_result.get('success', False),
+                'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
+                'output_file': stage_result.get('output_file'),
+                'summary': stage_result.get('summary', {})
             }
-            for stage_name, stage_result in self.results['stages'].items():
-                clean_results['stages'][stage_name] = {
-                    'success': stage_result.get('success', False),
-                    'elapsed_seconds': stage_result.get('elapsed_seconds', 0),
-                    'output_file': stage_result.get('output_file'),
-                    'summary': stage_result.get('summary', {})
-                }
-            json.dump(clean_results, f, indent=2)
+        write_json(results_file, clean_results)
 
         print(f"Results summary: {results_file}")
 

--- a/libs/openant-core/parsers/ruby/test_pipeline.py
+++ b/libs/openant-core/parsers/ruby/test_pipeline.py
@@ -43,8 +43,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Set
 
-# Add parent directory to path for utilities import
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from utilities.context_enhancer import ContextEnhancer
 from utilities.agentic_enhancer import EntryPointDetector, ReachabilityAnalyzer
 from utilities.file_io import read_json, write_json, open_utf8

--- a/libs/openant-core/parsers/ruby/unit_generator.py
+++ b/libs/openant-core/parsers/ruby/unit_generator.py
@@ -29,6 +29,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+from utilities.file_io import read_json, write_json
+
 
 # File boundary marker for enhanced code (Ruby uses # comments)
 FILE_BOUNDARY = '\n\n# ========== File Boundary ==========\n\n'
@@ -344,8 +346,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        with open(args.input_file) as f:
-            call_graph_data = json.load(f)
+        call_graph_data = read_json(args.input_file)
 
         options = {
             'max_depth': args.depth,
@@ -374,8 +375,7 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            with open(args.output, 'w') as f:
-                f.write(output)
+            write_json(args.output, result)
             print(f"\nOutput written to: {args.output}", file=sys.stderr)
         else:
             print(output)
@@ -383,8 +383,7 @@ Examples:
         # Write analyzer output if requested
         if args.analyzer_output:
             analyzer = generator.generate_analyzer_output()
-            with open(args.analyzer_output, 'w') as f:
-                json.dump(analyzer, f, indent=2)
+            write_json(args.analyzer_output, analyzer)
             print(f"Analyzer output written to: {args.analyzer_output}", file=sys.stderr)
 
     except Exception as e:

--- a/libs/openant-core/parsers/ruby/unit_generator.py
+++ b/libs/openant-core/parsers/ruby/unit_generator.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from utilities.file_io import read_json, write_json
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 # File boundary marker for enhanced code (Ruby uses # comments)
@@ -375,7 +375,8 @@ Examples:
         output = json.dumps(result, indent=2)
 
         if args.output:
-            write_json(args.output, result)
+            with open_utf8(args.output, 'w') as f:
+                f.write(output)
             print(f"\nOutput written to: {args.output}", file=sys.stderr)
         else:
             print(output)

--- a/libs/openant-core/tests/test_file_io.py
+++ b/libs/openant-core/tests/test_file_io.py
@@ -1,0 +1,173 @@
+"""Tests for the centralized file I/O and subprocess helpers."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utilities.file_io import open_utf8, read_json, write_json, run_utf8
+
+
+class TestOpenUtf8:
+    def test_defaults_to_utf8_encoding(self, tmp_path):
+        path = tmp_path / "test.txt"
+        # Write a file with non-ASCII UTF-8 content
+        content = "hello \u2019world\u2019 caf\u00e9"  # curly quotes + accented char
+        with open_utf8(str(path), "w") as f:
+            f.write(content)
+
+        with open_utf8(str(path), "r") as f:
+            assert f.read() == content
+
+    def test_handles_byte_0x9d(self, tmp_path):
+        """Reproduce the original Windows charmap error: byte 0x9d."""
+        path = tmp_path / "test.json"
+        # 0x9d in cp1252 is undefined, but valid in UTF-8 as part of \u009d
+        # The original error was from source code containing curly quotes
+        # (U+2019 = 0xe2 0x80 0x99 in UTF-8)
+        content = '{"code": "const x = \\u2018hello\\u2019"}'
+        path.write_text(content, encoding="utf-8")
+
+        with open_utf8(str(path), "r") as f:
+            data = json.load(f)
+        assert "code" in data
+
+    def test_respects_explicit_encoding(self, tmp_path):
+        path = tmp_path / "latin.txt"
+        path.write_bytes(b"caf\xe9")  # latin-1 encoded "café"
+
+        with open_utf8(str(path), "r", encoding="latin-1") as f:
+            assert f.read() == "caf\u00e9"
+
+    def test_binary_mode_skips_encoding(self, tmp_path):
+        path = tmp_path / "binary.bin"
+        path.write_bytes(b"\x00\x01\x02")
+
+        with open_utf8(str(path), "rb") as f:
+            assert f.read() == b"\x00\x01\x02"
+
+
+class TestReadJson:
+    def test_reads_utf8_json(self, tmp_path):
+        path = tmp_path / "data.json"
+        data = {"name": "caf\u00e9", "emoji": "\u2728"}
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+        result = read_json(str(path))
+        assert result == data
+
+    def test_reads_json_with_problematic_bytes(self, tmp_path):
+        """Ensure JSON with source code snippets containing non-ASCII works."""
+        path = tmp_path / "analyzer_output.json"
+        # Simulate analyzer output with curly quotes in source code
+        data = {
+            "functions": {
+                "app.ts:getUser": {
+                    "code": "// Returns the user\u2019s profile",
+                    "name": "getUser",
+                }
+            }
+        }
+        path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+        result = read_json(str(path))
+        assert "\u2019" in result["functions"]["app.ts:getUser"]["code"]
+
+
+class TestWriteJson:
+    def test_writes_utf8_json(self, tmp_path):
+        path = tmp_path / "out.json"
+        data = {"value": "caf\u00e9 \u2019"}
+        write_json(str(path), data)
+
+        # json.dump defaults to ensure_ascii=True, so non-ASCII is escaped
+        raw = path.read_bytes()
+        result = json.loads(raw.decode("utf-8"))
+        assert result == data
+
+    def test_default_indent(self, tmp_path):
+        path = tmp_path / "out.json"
+        write_json(str(path), {"a": 1})
+
+        text = path.read_text(encoding="utf-8")
+        assert "  " in text  # default indent=2
+
+    def test_custom_indent(self, tmp_path):
+        path = tmp_path / "out.json"
+        write_json(str(path), {"a": 1}, indent=4)
+
+        text = path.read_text(encoding="utf-8")
+        assert "    " in text
+
+
+class TestRunUtf8:
+    def test_sets_utf8_encoding_in_text_mode(self):
+        result = run_utf8(
+            [sys.executable, "-c", 'import sys; sys.stdout.buffer.write("caf\u00e9\\n".encode("utf-8"))'],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "caf\u00e9" in result.stdout
+
+    def test_sets_errors_replace(self):
+        # Output raw bytes that aren't valid UTF-8
+        result = run_utf8(
+            [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'hello\\x9dworld')"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # The invalid byte should be replaced rather than raising an error
+        assert "hello" in result.stdout
+        assert "world" in result.stdout
+
+    def test_no_encoding_without_text_mode(self):
+        result = run_utf8(
+            [sys.executable, "-c", "print('hello')"],
+            capture_output=True,
+        )
+        assert result.returncode == 0
+        # Without text=True, stdout is bytes
+        assert isinstance(result.stdout, bytes)
+
+    def test_respects_explicit_encoding(self):
+        result = run_utf8(
+            [sys.executable, "-c", "print('hello')"],
+            capture_output=True,
+            text=True,
+            encoding="ascii",
+        )
+        assert result.returncode == 0
+        assert "hello" in result.stdout
+
+
+class TestRoundTrip:
+    """End-to-end test: write JSON with non-ASCII, read it back."""
+
+    def test_write_read_roundtrip_with_source_code(self, tmp_path):
+        """Simulate the actual parser pipeline: write analyzer output, read it back."""
+        path = str(tmp_path / "analyzer_output.json")
+
+        # Data that mimics real analyzer output with non-ASCII source code
+        original = {
+            "functions": {
+                "src/api.ts:handleRequest": {
+                    "name": "handleRequest",
+                    "code": 'const msg = "User\u2019s request";  // em dash \u2014 here',
+                    "startLine": 10,
+                    "endLine": 25,
+                }
+            },
+            "callGraph": {},
+        }
+
+        write_json(path, original)
+        loaded = read_json(path)
+
+        assert loaded == original
+        assert "\u2019" in loaded["functions"]["src/api.ts:handleRequest"]["code"]
+        assert "\u2014" in loaded["functions"]["src/api.ts:handleRequest"]["code"]

--- a/libs/openant-core/tests/test_js_parser.py
+++ b/libs/openant-core/tests/test_js_parser.py
@@ -4,9 +4,10 @@ Requires Node.js and npm dependencies installed:
   cd parsers/javascript && npm install
 """
 import json
-import subprocess
 import shutil
 from pathlib import Path
+
+from utilities.file_io import run_utf8
 
 import pytest
 
@@ -23,7 +24,7 @@ pytestmark = pytest.mark.skipif(
 def run_node(script_name, *args):
     """Run a Node.js script from the JS parsers directory."""
     cmd = ["node", str(PARSERS_JS_DIR / script_name)] + list(args)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    result = run_utf8(cmd, capture_output=True, text=True, timeout=30)
     return result
 
 

--- a/libs/openant-core/tests/test_parser_adapter.py
+++ b/libs/openant-core/tests/test_parser_adapter.py
@@ -1,11 +1,11 @@
 """Tests for core/parser_adapter.py — language detection and Python parsing."""
-import json
 import os
 from pathlib import Path
 
 import pytest
 
 from core.parser_adapter import detect_language, parse_repository
+from utilities.file_io import read_json
 
 
 class TestDetectLanguage:
@@ -65,8 +65,7 @@ class TestParseRepositoryPython:
             language="python",
             processing_level="all",
         )
-        with open(result.dataset_path) as f:
-            dataset = json.load(f)
+        dataset = read_json(result.dataset_path)
         assert "units" in dataset
         assert len(dataset["units"]) > 0
 
@@ -77,8 +76,7 @@ class TestParseRepositoryPython:
             language="python",
             processing_level="all",
         )
-        with open(result.dataset_path) as f:
-            dataset = json.load(f)
+        dataset = read_json(result.dataset_path)
         for unit in dataset["units"]:
             assert "id" in unit
             assert "code" in unit
@@ -101,6 +99,5 @@ class TestParseRepositoryPython:
         )
         assert result.analyzer_output_path is not None
         assert Path(result.analyzer_output_path).exists()
-        with open(result.analyzer_output_path) as f:
-            data = json.load(f)
+        data = read_json(result.analyzer_output_path)
         assert "functions" in data

--- a/libs/openant-core/tests/test_resume_stage1.py
+++ b/libs/openant-core/tests/test_resume_stage1.py
@@ -14,6 +14,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from core.utils import atomic_write_json
+from utilities.file_io import read_json, write_json
 
 
 # ---------------------------------------------------------------------------
@@ -28,8 +29,7 @@ class TestAtomicWriteJson:
         data = {"key": "value", "number": 42}
         atomic_write_json(path, data)
 
-        with open(path) as f:
-            loaded = json.load(f)
+        loaded = read_json(path)
         assert loaded == data
 
     def test_atomic_write_no_partial_on_error(self, tmp_path):
@@ -48,8 +48,7 @@ class TestAtomicWriteJson:
         """If serialization fails, existing target file is not modified."""
         path = str(tmp_path / "output.json")
         original = {"original": True}
-        with open(path, "w") as f:
-            json.dump(original, f)
+        write_json(path, original)
 
         class Unserializable:
             pass
@@ -58,8 +57,7 @@ class TestAtomicWriteJson:
             atomic_write_json(path, {"bad": Unserializable()})
 
         # Original file should still be intact
-        with open(path) as f:
-            loaded = json.load(f)
+        loaded = read_json(path)
         assert loaded == original
 
     def test_atomic_write_overwrites_atomically(self, tmp_path):
@@ -72,8 +70,7 @@ class TestAtomicWriteJson:
         # Overwrite
         atomic_write_json(path, {"version": 2, "data": [1, 2, 3]})
 
-        with open(path) as f:
-            loaded = json.load(f)
+        loaded = read_json(path)
         assert loaded == {"version": 2, "data": [1, 2, 3]}
 
     def test_atomic_write_creates_parent_dirs(self, tmp_path):
@@ -81,8 +78,7 @@ class TestAtomicWriteJson:
         path = str(tmp_path / "sub" / "dir" / "output.json")
         atomic_write_json(path, {"nested": True})
 
-        with open(path) as f:
-            loaded = json.load(f)
+        loaded = read_json(path)
         assert loaded == {"nested": True}
 
     def test_atomic_write_no_temp_files_left(self, tmp_path):
@@ -118,14 +114,12 @@ def _make_dataset(tmp_path, num_units=3):
 
     dataset = {"units": units, "metadata": {}}
     dataset_path = str(tmp_path / "dataset.json")
-    with open(dataset_path, "w") as f:
-        json.dump(dataset, f)
+    write_json(dataset_path, dataset)
 
     # Create minimal analyzer output
     analyzer_output = {"functions": {}, "files": {}}
     ao_path = str(tmp_path / "analyzer_output.json")
-    with open(ao_path, "w") as f:
-        json.dump(analyzer_output, f)
+    write_json(ao_path, analyzer_output)
 
     return dataset_path, ao_path
 
@@ -209,13 +203,11 @@ class TestEnhanceAutoCheckpoint:
         assert result.units_enhanced == 5
 
         # Simulate a partial checkpoint by writing back only 2 processed units
-        with open(output_path) as f:
-            completed = json.load(f)
+        completed = read_json(output_path)
         for unit in completed["units"][2:]:
             unit.pop("agent_context", None)
         completed["metadata"]["checkpoint"] = True
-        with open(checkpoint_path, "w") as f:
-            json.dump(completed, f)
+        write_json(checkpoint_path, completed)
         # Remove output so enhance doesn't skip entirely
         os.remove(output_path)
 
@@ -248,8 +240,7 @@ class TestEnhanceAutoCheckpoint:
         checkpoint_path = str(tmp_path / "enhanced_checkpoint.json")
 
         # Create a fake checkpoint
-        with open(checkpoint_path, "w") as f:
-            json.dump({"units": [], "metadata": {}}, f)
+        write_json(checkpoint_path, {"units": [], "metadata": {}})
 
         result = enhance_dataset(
             dataset_path=dataset_path,

--- a/libs/openant-core/tests/test_resume_stage2.py
+++ b/libs/openant-core/tests/test_resume_stage2.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from core.utils import atomic_write_json
+from utilities.file_io import read_json, write_json, open_utf8
 
 # Pre-import modules so we can patch attributes on them
 import core.analyzer as analyzer_mod
@@ -46,8 +47,7 @@ def _make_dataset(tmp_path, num_units=5):
 
     dataset = {"units": units, "metadata": {}}
     dataset_path = str(tmp_path / "dataset.json")
-    with open(dataset_path, "w") as f:
-        json.dump(dataset, f)
+    write_json(dataset_path, dataset)
 
     return dataset_path
 
@@ -82,14 +82,12 @@ def _make_results(tmp_path, num_results=5, vulnerable_count=2):
     }
 
     results_path = str(tmp_path / "results.json")
-    with open(results_path, "w") as f:
-        json.dump(experiment, f)
+    write_json(results_path, experiment)
 
     # Create a minimal analyzer_output.json
     ao = {"functions": {}, "files": {}}
     ao_path = str(tmp_path / "analyzer_output.json")
-    with open(ao_path, "w") as f:
-        json.dump(ao, f)
+    write_json(ao_path, ao)
 
     return results_path, ao_path
 
@@ -246,8 +244,7 @@ class TestAnalyzeCheckpoint:
 
         # Checkpoint should exist with the 2 completed units
         assert os.path.exists(checkpoint_path)
-        with open(checkpoint_path) as f:
-            cp = json.load(f)
+        cp = read_json(checkpoint_path)
         assert len(cp["results"]) == 2
 
         # Second run: all succeed — should skip the 2 already done
@@ -302,7 +299,7 @@ class TestAnalyzeCheckpoint:
 
         # Create corrupt checkpoint
         os.makedirs(output_dir, exist_ok=True)
-        with open(checkpoint_path, "w") as f:
+        with open_utf8(checkpoint_path, "w") as f:
             f.write("{corrupt json!!!}")
 
         with patch.object(analyzer_mod, "AnthropicClient"), \
@@ -415,8 +412,7 @@ class TestAnalyzeCheckpoint:
 
         _save_analyze_checkpoint(checkpoint_path, results, code_by_route, counts, "dataset.json", "opus")
 
-        with open(checkpoint_path) as f:
-            cp = json.load(f)
+        cp = read_json(checkpoint_path)
 
         assert len(cp["results"]) == 2
         assert cp["code_by_route"] == code_by_route
@@ -597,8 +593,7 @@ class TestVerifyBatchCheckpoint:
 
         _save_verify_checkpoint(checkpoint_path, results, completed_keys)
 
-        with open(checkpoint_path) as f:
-            cp = json.load(f)
+        cp = read_json(checkpoint_path)
 
         assert set(cp["completed_keys"]) == {"route_0"}
         assert len(cp["verified"]) == 1

--- a/libs/openant-core/tests/test_resume_stage3.py
+++ b/libs/openant-core/tests/test_resume_stage3.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from core.scanner import _check_step_completed, _load_parse_state, _load_analyze_state, _load_verify_state
 from core.schemas import UsageInfo
+from utilities.file_io import read_json, write_json, open_utf8
 
 
 # ---------------------------------------------------------------------------
@@ -24,8 +25,7 @@ from core.schemas import UsageInfo
 def _write_json(path, data):
     """Write JSON to a file, creating parent dirs."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f)
+    write_json(path, data)
 
 
 def _make_step_report(output_dir, step, status="success", summary=None, outputs=None):
@@ -67,8 +67,7 @@ def _setup_parse_complete(output_dir, units_count=5, language="python"):
 def _setup_enhance_complete(output_dir, dataset_path):
     """Set up a completed enhance step with output files."""
     enhanced_path = os.path.join(output_dir, "dataset_enhanced.json")
-    with open(dataset_path) as f:
-        dataset = json.load(f)
+    dataset = read_json(dataset_path)
     for unit in dataset.get("units", []):
         unit["agent_context"] = {"security_classification": "neutral"}
     _write_json(enhanced_path, dataset)
@@ -117,7 +116,7 @@ def _setup_report_complete(output_dir):
     report_dir = os.path.join(output_dir, "report")
     os.makedirs(report_dir, exist_ok=True)
     summary_path = os.path.join(report_dir, "SUMMARY_REPORT.md")
-    with open(summary_path, "w") as f:
+    with open_utf8(summary_path, "w") as f:
         f.write("# Summary Report\n")
 
     _make_step_report(output_dir, "report",
@@ -160,7 +159,7 @@ class TestCheckStepCompleted:
     def test_check_step_corrupt_json(self, tmp_path):
         """Report file with invalid JSON -> returns None."""
         report_path = str(tmp_path / "parse.report.json")
-        with open(report_path, "w") as f:
+        with open_utf8(report_path, "w") as f:
             f.write("{invalid json")
         assert _check_step_completed(str(tmp_path), "parse") is None
 
@@ -168,7 +167,7 @@ class TestCheckStepCompleted:
         """Report says success but output file is invalid JSON -> returns None."""
         output_dir = str(tmp_path)
         dataset_path = os.path.join(output_dir, "dataset.json")
-        with open(dataset_path, "w") as f:
+        with open_utf8(dataset_path, "w") as f:
             f.write("{truncated")
         _make_step_report(output_dir, "parse",
                           outputs={"dataset_path": dataset_path})
@@ -187,7 +186,7 @@ class TestCheckStepCompleted:
         output_dir = str(tmp_path)
         md_path = os.path.join(output_dir, "report", "SUMMARY_REPORT.md")
         os.makedirs(os.path.dirname(md_path), exist_ok=True)
-        with open(md_path, "w") as f:
+        with open_utf8(md_path, "w") as f:
             f.write("# Report\n")
         _make_step_report(output_dir, "report",
                           outputs={"summary_path": md_path})
@@ -534,8 +533,7 @@ class TestScanResumeIntegration:
             )
 
         scan_report_path = os.path.join(output_dir, "scan.report.json")
-        with open(scan_report_path) as f:
-            scan_report = json.load(f)
+        scan_report = read_json(scan_report_path)
 
         assert "steps_resumed" in scan_report["summary"]
         assert len(scan_report["summary"]["steps_resumed"]) > 0

--- a/libs/openant-core/utilities/agentic_enhancer/repository_index.py
+++ b/libs/openant-core/utilities/agentic_enhancer/repository_index.py
@@ -19,6 +19,8 @@ import re
 from pathlib import Path
 from typing import Optional
 
+from ..file_io import read_json
+
 
 class RepositoryIndex:
     """
@@ -283,7 +285,6 @@ def load_index_from_file(analyzer_output_path: str, repo_path: str = None) -> Re
     Returns:
         RepositoryIndex instance
     """
-    with open(analyzer_output_path, 'r') as f:
-        analyzer_output = json.load(f)
+    analyzer_output = read_json(analyzer_output_path)
 
     return RepositoryIndex(analyzer_output, repo_path)

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 from typing import Callable, Optional
 
+from .file_io import read_json, write_json
 from .llm_client import AnthropicClient, TokenTracker, get_global_tracker
 from .agentic_enhancer import enhance_unit_with_agent, load_index_from_file
 
@@ -375,8 +376,7 @@ class ContextEnhancer:
             checkpoint_file = Path(checkpoint_path)
             if checkpoint_file.exists():
                 self._log("info", f"Found checkpoint at {checkpoint_path}, resuming...")
-                with open(checkpoint_file, 'r') as f:
-                    checkpoint_data = json.load(f)
+                checkpoint_data = read_json(checkpoint_file)
 
                 # Build set of already-processed unit IDs
                 for cp_unit in checkpoint_data.get("units", []):
@@ -657,8 +657,7 @@ def main():
         logging.error(f"Error: Input file not found: {input_path}")
         return 1
 
-    with open(input_path, 'r') as f:
-        dataset = json.load(f)
+    dataset = read_json(input_path)
 
     # Enhance
     enhancer = ContextEnhancer()
@@ -688,8 +687,7 @@ def main():
 
     # Write output
     output_path = Path(args.output) if args.output else input_path
-    with open(output_path, 'w') as f:
-        json.dump(enhanced, f, indent=2)
+    write_json(output_path, enhanced)
 
     logging.info(f"Enhanced dataset written to: {output_path}")
     return 0

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -7,7 +7,6 @@ Public API:
     run_dynamic_tests(pipeline_output_path, output_dir) -> list[DynamicTestResult]
 """
 
-import json
 import os
 import sys
 
@@ -139,11 +138,11 @@ def run_dynamic_tests(
     # Save structured results JSON
     results_path = os.path.join(output_dir, "dynamic_test_results.json")
     write_json(results_path, {
-            "repository": repo_info["name"],
-            "total_findings": len(findings),
-            "total_cost_usd": round(total_cost, 6),
-            "results": [r.to_dict() for r in results],
-        }, ensure_ascii=False)
+        "repository": repo_info["name"],
+        "total_findings": len(findings),
+        "total_cost_usd": round(total_cost, 6),
+        "results": [r.to_dict() for r in results],
+    }, ensure_ascii=False)
     print(f"Results JSON written to {results_path}", file=sys.stderr)
 
     return results

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 
+from utilities.file_io import read_json, write_json, open_utf8
 from utilities.dynamic_tester.models import DynamicTestResult
 from utilities.dynamic_tester.test_generator import generate_test, regenerate_test
 from utilities.dynamic_tester.docker_executor import run_single_container
@@ -35,8 +36,7 @@ def run_dynamic_tests(
         List of DynamicTestResult objects
     """
     # Load pipeline output
-    with open(pipeline_output_path, "r") as f:
-        pipeline = json.load(f)
+    pipeline = read_json(pipeline_output_path)
 
     findings = pipeline.get("findings", [])
     repo_info = {
@@ -132,19 +132,18 @@ def run_dynamic_tests(
     report_md = generate_report(results, repo_info["name"], total_cost)
 
     report_path = os.path.join(output_dir, "DYNAMIC_TEST_RESULTS.md")
-    with open(report_path, "w") as f:
+    with open_utf8(report_path, "w") as f:
         f.write(report_md)
     print(f"\nReport written to {report_path}", file=sys.stderr)
 
     # Save structured results JSON
     results_path = os.path.join(output_dir, "dynamic_test_results.json")
-    with open(results_path, "w") as f:
-        json.dump({
+    write_json(results_path, {
             "repository": repo_info["name"],
             "total_findings": len(findings),
             "total_cost_usd": round(total_cost, 6),
             "results": [r.to_dict() for r in results],
-        }, f, indent=2, ensure_ascii=False)
+        }, ensure_ascii=False)
     print(f"Results JSON written to {results_path}", file=sys.stderr)
 
     return results

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -12,6 +12,8 @@ import subprocess
 import tempfile
 import time
 
+from utilities.file_io import open_utf8
+
 # Timeouts
 DEFAULT_CONTAINER_TIMEOUT = 120   # seconds per container
 DEFAULT_BUILD_TIMEOUT = 300       # seconds for docker build
@@ -61,18 +63,18 @@ def _sanitize_compose(content: str) -> str:
 def _write_test_files(work_dir: str, generation: dict) -> None:
     """Write generated test files into the working directory."""
     # Write Dockerfile
-    with open(os.path.join(work_dir, "Dockerfile"), "w") as f:
+    with open_utf8(os.path.join(work_dir, "Dockerfile"), "w") as f:
         f.write(generation["dockerfile"])
 
     # Write test script
     test_filename = generation.get("test_filename", "test_exploit.py")
-    with open(os.path.join(work_dir, test_filename), "w") as f:
+    with open_utf8(os.path.join(work_dir, test_filename), "w") as f:
         f.write(generation["test_script"])
 
     # Write requirements/dependencies file
     if generation.get("requirements"):
         req_filename = generation.get("requirements_filename", "requirements.txt")
-        with open(os.path.join(work_dir, req_filename), "w") as f:
+        with open_utf8(os.path.join(work_dir, req_filename), "w") as f:
             f.write(generation["requirements"])
 
     # Copy attacker server if needed (before docker-compose so it's available)
@@ -81,14 +83,14 @@ def _write_test_files(work_dir: str, generation: dict) -> None:
         os.makedirs(attacker_dir, exist_ok=True)
         shutil.copy2(ATTACKER_SERVER_PATH, os.path.join(attacker_dir, "server.py"))
         # Write attacker Dockerfile
-        with open(os.path.join(attacker_dir, "Dockerfile"), "w") as f:
+        with open_utf8(os.path.join(attacker_dir, "Dockerfile"), "w") as f:
             f.write("FROM python:3.11-slim\nWORKDIR /app\nCOPY server.py .\n"
                     "EXPOSE 9999\nCMD [\"python\", \"server.py\"]\n")
 
     # Write docker-compose if multi-service, with sanitization
     if generation.get("docker_compose"):
         compose_content = _sanitize_compose(generation["docker_compose"])
-        with open(os.path.join(work_dir, "docker-compose.yml"), "w") as f:
+        with open_utf8(os.path.join(work_dir, "docker-compose.yml"), "w") as f:
             f.write(compose_content)
 
 

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 import time
 
-from utilities.file_io import open_utf8
+from utilities.file_io import open_utf8, run_utf8
 
 # Timeouts
 DEFAULT_CONTAINER_TIMEOUT = 120   # seconds per container
@@ -97,7 +97,7 @@ def _write_test_files(work_dir: str, generation: dict) -> None:
 def _run_command(cmd: list[str], timeout: int, cwd: str = None) -> tuple[str, str, int, bool]:
     """Run a command with timeout. Returns (stdout, stderr, exit_code, timed_out)."""
     try:
-        result = subprocess.run(
+        result = run_utf8(
             cmd,
             capture_output=True,
             text=True,

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -46,6 +46,12 @@ def run_utf8(*args, **kwargs) -> subprocess.CompletedProcess:
     Wrapper around ``subprocess.run`` that sets ``encoding='utf-8'`` and
     ``errors='replace'`` when ``text=True`` is passed, preventing charmap
     decode errors on Windows.
+
+    Note: ``errors='replace'`` substitutes U+FFFD for invalid bytes in
+    stdout/stderr rather than raising.  This is intentional — subprocess
+    output is used for status display and diagnostics, not for security
+    analysis (parser results are read from JSON files separately).
+    Callers can override with ``errors='strict'`` if needed.
     """
     if kwargs.get("text"):
         kwargs.setdefault("encoding", "utf-8")

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -7,11 +7,15 @@ explicitly, preventing ``'charmap' codec can't decode byte ...`` errors.
 """
 
 import json
+import os
 import subprocess
-from typing import Any
+from typing import Any, Union
+
+# Accept str, Path, or any os.PathLike
+PathLike = Union[str, os.PathLike]
 
 
-def open_utf8(path: str, mode: str = "r", **kwargs):
+def open_utf8(path: PathLike, mode: str = "r", **kwargs):
     """Open a file with UTF-8 encoding by default.
 
     Drop-in replacement for ``open()`` that sets ``encoding='utf-8'`` unless
@@ -23,13 +27,13 @@ def open_utf8(path: str, mode: str = "r", **kwargs):
     return open(path, mode, **kwargs)
 
 
-def read_json(path: str) -> Any:
+def read_json(path: PathLike) -> Any:
     """Read and parse a JSON file using UTF-8 encoding."""
     with open_utf8(path, "r") as f:
         return json.load(f)
 
 
-def write_json(path: str, data: Any, **kwargs) -> None:
+def write_json(path: PathLike, data: Any, **kwargs) -> None:
     """Write data as JSON to a file using UTF-8 encoding."""
     kwargs.setdefault("indent", 2)
     with open_utf8(path, "w") as f:

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -1,0 +1,49 @@
+"""Centralized file I/O and subprocess helpers for Windows UTF-8 compatibility.
+
+On Windows, Python's default encoding is often ``cp1252`` (charmap), which
+cannot decode common UTF-8 sequences found in source code.  These thin
+wrappers ensure that every file open and subprocess call uses UTF-8
+explicitly, preventing ``'charmap' codec can't decode byte ...`` errors.
+"""
+
+import json
+import subprocess
+from typing import Any
+
+
+def open_utf8(path: str, mode: str = "r", **kwargs):
+    """Open a file with UTF-8 encoding by default.
+
+    Drop-in replacement for ``open()`` that sets ``encoding='utf-8'`` unless
+    the caller explicitly provides a different encoding or opens in binary
+    mode.
+    """
+    if "b" not in mode and "encoding" not in kwargs:
+        kwargs["encoding"] = "utf-8"
+    return open(path, mode, **kwargs)
+
+
+def read_json(path: str) -> Any:
+    """Read and parse a JSON file using UTF-8 encoding."""
+    with open_utf8(path, "r") as f:
+        return json.load(f)
+
+
+def write_json(path: str, data: Any, **kwargs) -> None:
+    """Write data as JSON to a file using UTF-8 encoding."""
+    kwargs.setdefault("indent", 2)
+    with open_utf8(path, "w") as f:
+        json.dump(data, f, **kwargs)
+
+
+def run_utf8(*args, **kwargs) -> subprocess.CompletedProcess:
+    """Run a subprocess with UTF-8 encoding for text mode.
+
+    Wrapper around ``subprocess.run`` that sets ``encoding='utf-8'`` and
+    ``errors='replace'`` when ``text=True`` is passed, preventing charmap
+    decode errors on Windows.
+    """
+    if kwargs.get("text"):
+        kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("errors", "replace")
+    return subprocess.run(*args, **kwargs)

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -53,7 +53,7 @@ def run_utf8(*args, **kwargs) -> subprocess.CompletedProcess:
     analysis (parser results are read from JSON files separately).
     Callers can override with ``errors='strict'`` if needed.
     """
-    if kwargs.get("text"):
+    if kwargs.get("text") or kwargs.get("universal_newlines"):
         kwargs.setdefault("encoding", "utf-8")
         kwargs.setdefault("errors", "replace")
     return subprocess.run(*args, **kwargs)

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -36,6 +36,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from .file_io import read_json
 from .llm_client import TokenTracker, get_global_tracker, create_anthropic_client, create_message
 
 # Null logger that discards all messages (used when no logger provided)
@@ -435,8 +436,7 @@ class FindingVerifier:
         completed_keys = set()
         if checkpoint_path and os.path.exists(checkpoint_path):
             try:
-                with open(checkpoint_path) as f:
-                    cp = json.load(f)
+                cp = read_json(checkpoint_path)
                 completed_keys = set(cp.get("completed_keys", []))
                 # Restore verification data from checkpoint into results
                 cp_by_key = {r["route_key"]: r for r in cp.get("verified", [])}

--- a/libs/openant-core/utilities/local_claude.py
+++ b/libs/openant-core/utilities/local_claude.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 import uuid
 
+from .file_io import run_utf8
+
 
 def is_enabled() -> bool:
     """Check if local Claude Code mode is enabled."""
@@ -50,7 +52,7 @@ def _run_claude_cli(prompt: str, model: str, system: str = None) -> dict:
     # Unset CLAUDECODE to allow spawning from within a Claude Code session
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
-    result = subprocess.run(
+    result = run_utf8(
         cmd,
         capture_output=True,
         text=True,

--- a/libs/openant-core/validate_dataset_schema.py
+++ b/libs/openant-core/validate_dataset_schema.py
@@ -7,7 +7,15 @@ Run BEFORE any expensive LLM operations.
 """
 
 import json
+import os
 import sys
+
+# Ensure project root is on sys.path for utilities imports
+_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from utilities.file_io import read_json
 
 
 def validate_unit(unit, index):
@@ -59,8 +67,7 @@ def validate_unit(unit, index):
 
 
 def validate_dataset(path):
-    with open(path) as f:
-        data = json.load(f)
+    data = read_json(path)
 
     all_errors = []
     units = data.get("units", [])

--- a/libs/openant-core/validate_dataset_schema.py
+++ b/libs/openant-core/validate_dataset_schema.py
@@ -7,13 +7,7 @@ Run BEFORE any expensive LLM operations.
 """
 
 import json
-import os
 import sys
-
-# Ensure project root is on sys.path for utilities imports
-_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
 
 from utilities.file_io import read_json
 

--- a/libs/openant-core/validate_dataset_schema.py
+++ b/libs/openant-core/validate_dataset_schema.py
@@ -6,7 +6,6 @@ Validates that a dataset matches the exact schema expected by experiment.py
 Run BEFORE any expensive LLM operations.
 """
 
-import json
 import sys
 
 from utilities.file_io import read_json


### PR DESCRIPTION
## Summary
- Fixes `'charmap' codec can't decode byte 0x9d` error when parsing/enhancing repos containing non-ASCII source code on Windows
- Adds `utilities/file_io.py` with centralized `open_utf8`, `read_json`, `write_json`, and `run_utf8` helpers that default to UTF-8 encoding
- Migrates **all** bare `open()`/`subprocess.run()` calls across the codebase to use these helpers:
  - Core pipeline (`analyzer`, `enhancer`, `verifier`, `scanner`, `reporter`, `dynamic_tester`, `parser_adapter`)
  - All parsers (JavaScript, Go, Python, C, PHP, Ruby)
  - Utilities (`context_enhancer`, `dynamic_tester`)
  - Standalone scripts (`experiment`, `export_csv`, `generate_report`, `validate_dataset_schema`)
  - CLI (`openant/cli.py`) and test helpers (`test_js_parser.py`)

## Test plan
- [x] 14 new tests in `test_file_io.py` covering all helpers, edge cases (byte 0x9d, binary mode, explicit encoding override), and round-trip JSON with non-ASCII source code
- [x] All 176 tests pass (including `test_js_parser.py`, `test_parser_adapter.py`, `test_go_cli.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)