### PR TITLE
fix: pass prompt via stdin to avoid WinError 206 on Windows

### DIFF
--- a/libs/openant-core/tests/test_local_claude.py
+++ b/libs/openant-core/tests/test_local_claude.py
@@ -133,7 +133,7 @@ class TestIsEnabled:
 # ---------------------------------------------------------------------------
 
 class TestRunClaudeCli:
-    @patch("utilities.local_claude.subprocess.run")
+    @patch("utilities.local_claude.run_utf8")
     @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
     def test_parses_json_output_with_usage(self, mock_which, mock_run):
         mock_run.return_value = _make_completed_process(stdout=SAMPLE_CLI_OUTPUT)
@@ -145,7 +145,45 @@ class TestRunClaudeCli:
         assert result["output_tokens"] == 25
         assert result["cost_usd"] == 0.003
 
-    @patch("utilities.local_claude.subprocess.run")
+    @patch("utilities.local_claude.run_utf8")
+    @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
+    def test_passes_prompt_via_stdin(self, mock_which, mock_run):
+        """Prompt must be passed via stdin, not as a CLI arg (WinError 206 fix)."""
+        mock_run.return_value = _make_completed_process(stdout=SAMPLE_CLI_OUTPUT)
+
+        _run_claude_cli("my prompt text", model="m")
+
+        cmd = mock_run.call_args[0][0]
+        # -p flag should be present but prompt text should NOT be in the command
+        assert "-p" in cmd
+        assert "my prompt text" not in cmd
+        # Prompt should be passed via input kwarg (stdin)
+        assert mock_run.call_args[1]["input"] == "my prompt text"
+
+    @patch("utilities.local_claude.run_utf8")
+    @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
+    def test_stdin_prompt_with_system(self, mock_which, mock_run):
+        """System prompt is prepended and passed via stdin together."""
+        mock_run.return_value = _make_completed_process(stdout=SAMPLE_CLI_OUTPUT)
+
+        _run_claude_cli("user prompt", model="m", system="system instructions")
+
+        assert mock_run.call_args[1]["input"] == "system instructions\n\nuser prompt"
+
+    @patch("utilities.local_claude.run_utf8")
+    @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
+    def test_large_prompt_via_stdin(self, mock_which, mock_run):
+        """Prompts exceeding Windows cmd limit work via stdin."""
+        mock_run.return_value = _make_completed_process(stdout=SAMPLE_CLI_OUTPUT)
+        large_prompt = "x" * 10000  # Exceeds Windows 8191 char limit
+
+        _run_claude_cli(large_prompt, model="m")
+
+        cmd = mock_run.call_args[0][0]
+        assert large_prompt not in cmd
+        assert mock_run.call_args[1]["input"] == large_prompt
+
+    @patch("utilities.local_claude.run_utf8")
     @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
     def test_strips_claudecode_from_env(self, mock_which, mock_run):
         """Prevents 'nested session' error when run from within Claude Code."""
@@ -163,7 +201,7 @@ class TestRunClaudeCli:
         with pytest.raises(FileNotFoundError, match="claude CLI not found"):
             _run_claude_cli("test", model="m")
 
-    @patch("utilities.local_claude.subprocess.run")
+    @patch("utilities.local_claude.run_utf8")
     @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
     def test_raises_on_nonzero_exit(self, mock_which, mock_run):
         mock_run.return_value = _make_completed_process(returncode=1, stderr="auth failed")
@@ -171,7 +209,7 @@ class TestRunClaudeCli:
         with pytest.raises(RuntimeError, match="exit 1"):
             _run_claude_cli("test", model="m")
 
-    @patch("utilities.local_claude.subprocess.run")
+    @patch("utilities.local_claude.run_utf8")
     @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
     def test_handles_non_json_output(self, mock_which, mock_run):
         mock_run.return_value = _make_completed_process(stdout="plain text response")
@@ -181,7 +219,7 @@ class TestRunClaudeCli:
         assert result["text"] == "plain text response"
         assert result["input_tokens"] == 0
 
-    @patch("utilities.local_claude.subprocess.run")
+    @patch("utilities.local_claude.run_utf8")
     @patch("utilities.local_claude.shutil.which", return_value="/usr/bin/claude")
     def test_falls_back_to_stdout_when_result_empty(self, mock_which, mock_run):
         mock_run.return_value = _make_completed_process(stdout=SAMPLE_CLI_OUTPUT_NO_RESULT)

--- a/libs/openant-core/utilities/local_claude.py
+++ b/libs/openant-core/utilities/local_claude.py
@@ -43,7 +43,7 @@ def _run_claude_cli(prompt: str, model: str, system: str = None) -> dict:
         full_prompt = f"{system}\n\n{prompt}"
 
     cmd = [
-        claude_bin, "-p", full_prompt,
+        claude_bin, "-p",
         "--model", model,
         "--max-turns", "1",
         "--output-format", "json",
@@ -54,6 +54,7 @@ def _run_claude_cli(prompt: str, model: str, system: str = None) -> dict:
 
     result = run_utf8(
         cmd,
+        input=full_prompt,
         capture_output=True,
         text=True,
         timeout=300,


### PR DESCRIPTION
## Summary

- **Fix `[WinError 206] The filename or extension is too long`** when running agentic enhance on Windows with `OPENANT_LOCAL_CLAUDE=true`
- Pass prompt via **stdin** (`input=`) instead of as a CLI argument to `claude -p` in `_run_claude_cli()`
- Fix test mocks to target `run_utf8` (the actual function used) instead of `subprocess.run`

## Problem

`_run_claude_cli()` in `local_claude.py` passed the entire prompt as a positional argument:

```python
cmd = [claude_bin, "-p", full_prompt, "--model", model, ...]
```

Windows has a ~8191 character command-line limit. When processing large code units in agentic enhance mode (e.g. `saleor/settings.py` with 4-6 units), the combined system prompt + user prompt + code context exceeded this limit, causing all units from that file to fail with `WinError 206`.

## Fix

Remove the prompt from the command-line arguments and pipe it via stdin instead:

```python
cmd = [claude_bin, "-p", "--model", model, ...]

result = run_utf8(cmd, input=full_prompt, capture_output=True, text=True, ...)
```

The `claude -p` flag reads from stdin when no inline prompt is provided. This eliminates the command-line length constraint entirely — prompts of any size now work.

## Files changed

| File | Change |
|------|--------|
| `libs/openant-core/utilities/local_claude.py` | Remove prompt from cmd args, add `input=full_prompt` to `run_utf8()` call |
| `libs/openant-core/tests/test_local_claude.py` | Fix mocks (`run_utf8` not `subprocess.run`), add 3 new stdin tests |

## New tests

- `test_passes_prompt_via_stdin` — verifies prompt is in `input=` kwarg, not in cmd args
- `test_stdin_prompt_with_system` — verifies system + user prompt combined correctly via stdin
- `test_large_prompt_via_stdin` — verifies a 10,000 char prompt (exceeding Windows 8191 limit) works

## Test plan

- [x] `pytest tests/test_local_claude.py` — all 43 tests pass
- [ ] Manual smoke test: run `openant enhance --agentic` with `OPENANT_LOCAL_CLAUDE=true` on a dataset with large units (e.g. saleor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)