### PR TITLE
feat: auto-retry errored units in enhance and analyze commands

### DIFF
--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -45,7 +45,7 @@ func init() {
 	analyzeCmd.Flags().IntVar(&analyzeLimit, "limit", 0, "Max units to analyze (0 = no limit)")
 	analyzeCmd.Flags().StringVar(&analyzeModel, "model", "opus", "Model: opus or sonnet")
 	analyzeCmd.Flags().BoolVar(&analyzeFresh, "fresh", false, "Ignore checkpoint and reanalyze all units from scratch")
-	analyzeCmd.Flags().BoolVar(&analyzeSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them")
+	analyzeCmd.Flags().BoolVar(&analyzeSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them (errors are retried by default)")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {

--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -32,6 +32,7 @@ var (
 	analyzeLimit          int
 	analyzeModel          string
 	analyzeFresh          bool
+	analyzeRetryErrors    bool
 )
 
 func init() {
@@ -44,6 +45,7 @@ func init() {
 	analyzeCmd.Flags().IntVar(&analyzeLimit, "limit", 0, "Max units to analyze (0 = no limit)")
 	analyzeCmd.Flags().StringVar(&analyzeModel, "model", "opus", "Model: opus or sonnet")
 	analyzeCmd.Flags().BoolVar(&analyzeFresh, "fresh", false, "Ignore checkpoint and reanalyze all units from scratch")
+	analyzeCmd.Flags().BoolVar(&analyzeRetryErrors, "retry-errors", false, "Re-process only errored units from a previous completed run")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {
@@ -100,6 +102,9 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 	}
 	if analyzeFresh {
 		pyArgs = append(pyArgs, "--fresh")
+	}
+	if analyzeRetryErrors {
+		pyArgs = append(pyArgs, "--retry-errors")
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -32,7 +32,7 @@ var (
 	analyzeLimit          int
 	analyzeModel          string
 	analyzeFresh          bool
-	analyzeRetryErrors    bool
+	analyzeSkipErrors     bool
 )
 
 func init() {
@@ -45,7 +45,7 @@ func init() {
 	analyzeCmd.Flags().IntVar(&analyzeLimit, "limit", 0, "Max units to analyze (0 = no limit)")
 	analyzeCmd.Flags().StringVar(&analyzeModel, "model", "opus", "Model: opus or sonnet")
 	analyzeCmd.Flags().BoolVar(&analyzeFresh, "fresh", false, "Ignore checkpoint and reanalyze all units from scratch")
-	analyzeCmd.Flags().BoolVar(&analyzeRetryErrors, "retry-errors", false, "Re-process only errored units from a previous completed run")
+	analyzeCmd.Flags().BoolVar(&analyzeSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {
@@ -103,8 +103,8 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 	if analyzeFresh {
 		pyArgs = append(pyArgs, "--fresh")
 	}
-	if analyzeRetryErrors {
-		pyArgs = append(pyArgs, "--retry-errors")
+	if analyzeSkipErrors {
+		pyArgs = append(pyArgs, "--skip-errors")
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -37,7 +37,7 @@ func init() {
 	enhanceCmd.Flags().StringVar(&enhanceRepoPath, "repo-path", "", "Path to the repository (required for agentic mode)")
 	enhanceCmd.Flags().StringVar(&enhanceMode, "mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
 	enhanceCmd.Flags().BoolVar(&enhanceFresh, "fresh", false, "Ignore checkpoint and reprocess all units from scratch")
-	enhanceCmd.Flags().BoolVar(&enhanceSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them")
+	enhanceCmd.Flags().BoolVar(&enhanceSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them (errors are retried by default)")
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -28,6 +28,7 @@ var (
 	enhanceRepoPath       string
 	enhanceMode           string
 	enhanceFresh          bool
+	enhanceRetryErrors    bool
 )
 
 func init() {
@@ -36,6 +37,7 @@ func init() {
 	enhanceCmd.Flags().StringVar(&enhanceRepoPath, "repo-path", "", "Path to the repository (required for agentic mode)")
 	enhanceCmd.Flags().StringVar(&enhanceMode, "mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
 	enhanceCmd.Flags().BoolVar(&enhanceFresh, "fresh", false, "Ignore checkpoint and reprocess all units from scratch")
+	enhanceCmd.Flags().BoolVar(&enhanceRetryErrors, "retry-errors", false, "Re-process only errored units from a previous completed run")
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {
@@ -79,6 +81,9 @@ func runEnhance(cmd *cobra.Command, args []string) {
 	}
 	if enhanceFresh {
 		pyArgs = append(pyArgs, "--fresh")
+	}
+	if enhanceRetryErrors {
+		pyArgs = append(pyArgs, "--retry-errors")
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -28,7 +28,7 @@ var (
 	enhanceRepoPath       string
 	enhanceMode           string
 	enhanceFresh          bool
-	enhanceRetryErrors    bool
+	enhanceSkipErrors     bool
 )
 
 func init() {
@@ -37,7 +37,7 @@ func init() {
 	enhanceCmd.Flags().StringVar(&enhanceRepoPath, "repo-path", "", "Path to the repository (required for agentic mode)")
 	enhanceCmd.Flags().StringVar(&enhanceMode, "mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
 	enhanceCmd.Flags().BoolVar(&enhanceFresh, "fresh", false, "Ignore checkpoint and reprocess all units from scratch")
-	enhanceCmd.Flags().BoolVar(&enhanceRetryErrors, "retry-errors", false, "Re-process only errored units from a previous completed run")
+	enhanceCmd.Flags().BoolVar(&enhanceSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them")
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {
@@ -82,8 +82,8 @@ func runEnhance(cmd *cobra.Command, args []string) {
 	if enhanceFresh {
 		pyArgs = append(pyArgs, "--fresh")
 	}
-	if enhanceRetryErrors {
-		pyArgs = append(pyArgs, "--retry-errors")
+	if enhanceSkipErrors {
+		pyArgs = append(pyArgs, "--skip-errors")
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -83,6 +83,8 @@ def run_analysis(
             by the agentic enhancer (requires enhanced dataset).
         checkpoint_path: Path to save/resume checkpoint. Auto-generated if None.
         fresh: If True, delete existing checkpoint and reanalyze all units.
+        skip_errors: If True, skip errored units instead of retrying them.
+            By default, errored units are automatically retried on re-run.
 
     Returns:
         AnalyzeResult with results path, metrics, and usage.
@@ -116,7 +118,9 @@ def run_analysis(
 
             if error_count > 0 and not skip_errors:
                 # Copy completed results to checkpoint path so the resume
-                # logic re-processes errored units.
+                # logic re-processes errored units. This works because
+                # results.json and the checkpoint format share the same
+                # top-level keys ("results", "code_by_route").
                 shutil.copy2(results_path, checkpoint_path)
                 print(f"[Analyze] Retrying {error_count} errored units from: {results_path}", file=sys.stderr)
             else:
@@ -197,7 +201,8 @@ def run_analysis(
             results = cp.get("results", [])
             code_by_route = cp.get("code_by_route", {})
             if not skip_errors:
-                # Filter out errored results so they get reprocessed
+                # Filter out errored results so they get reprocessed.
+                # This zeroes their counts; they'll be recounted after reprocessing.
                 results = [r for r in results if r.get("verdict") != "ERROR"]
             completed_ids = {r["unit_id"] for r in results}
             # Recount from checkpoint

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -61,7 +61,7 @@ def run_analysis(
     exploitable_only: bool = False,
     checkpoint_path: str | None = None,
     fresh: bool = False,
-    retry_errors: bool = False,
+    skip_errors: bool = False,
 ) -> AnalyzeResult:
     """Run Stage 1 vulnerability detection on a dataset.
 
@@ -95,8 +95,8 @@ def run_analysis(
         checkpoint_path = os.path.join(output_dir, "analyze_checkpoint.json")
 
     # Validate flag combinations
-    if fresh and retry_errors:
-        raise ValueError("Cannot use both --fresh and --retry-errors")
+    if fresh and skip_errors:
+        raise ValueError("Cannot use both --fresh and --skip-errors")
 
     # Handle fresh mode
     if fresh:
@@ -106,18 +106,19 @@ def run_analysis(
         # Skip-when-already-complete: output exists and no checkpoint means previous run succeeded
         has_checkpoint = os.path.exists(checkpoint_path)
         if os.path.exists(results_path) and not has_checkpoint:
-            if retry_errors:
+            # Check if there are errored units worth retrying
+            experiment = read_json(results_path)
+            error_count = experiment.get("metrics", {}).get("errors", 0)
+
+            if error_count > 0 and not skip_errors:
                 # Copy completed results to checkpoint path so the resume
                 # logic re-processes errored units.
                 import shutil
                 shutil.copy2(results_path, checkpoint_path)
-                print(f"[Analyze] Retrying errored units from: {results_path}", file=sys.stderr)
+                print(f"[Analyze] Retrying {error_count} errored units from: {results_path}", file=sys.stderr)
             else:
                 print(f"[Analyze] Already complete: {results_path}", file=sys.stderr)
                 print("[Analyze] Use --fresh to reanalyze all units from scratch.", file=sys.stderr)
-                print("[Analyze] Use --retry-errors to reprocess only errored units.", file=sys.stderr)
-
-                experiment = read_json(results_path)
 
                 metrics_data = experiment.get("metrics", {})
                 metrics = AnalysisMetrics(
@@ -192,7 +193,7 @@ def run_analysis(
             cp = read_json(checkpoint_path)
             results = cp.get("results", [])
             code_by_route = cp.get("code_by_route", {})
-            if retry_errors:
+            if not skip_errors:
                 # Filter out errored results so they get reprocessed
                 results = [r for r in results if r.get("verdict") != "ERROR"]
             completed_ids = {r["unit_id"] for r in results}

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -61,6 +61,7 @@ def run_analysis(
     exploitable_only: bool = False,
     checkpoint_path: str | None = None,
     fresh: bool = False,
+    retry_errors: bool = False,
 ) -> AnalyzeResult:
     """Run Stage 1 vulnerability detection on a dataset.
 
@@ -93,6 +94,10 @@ def run_analysis(
     if checkpoint_path is None:
         checkpoint_path = os.path.join(output_dir, "analyze_checkpoint.json")
 
+    # Validate flag combinations
+    if fresh and retry_errors:
+        raise ValueError("Cannot use both --fresh and --retry-errors")
+
     # Handle fresh mode
     if fresh:
         if os.path.exists(checkpoint_path):
@@ -101,27 +106,35 @@ def run_analysis(
         # Skip-when-already-complete: output exists and no checkpoint means previous run succeeded
         has_checkpoint = os.path.exists(checkpoint_path)
         if os.path.exists(results_path) and not has_checkpoint:
-            print(f"[Analyze] Already complete: {results_path}", file=sys.stderr)
-            print("[Analyze] Use --fresh to reanalyze all units from scratch.", file=sys.stderr)
+            if retry_errors:
+                # Copy completed results to checkpoint path so the resume
+                # logic re-processes errored units.
+                import shutil
+                shutil.copy2(results_path, checkpoint_path)
+                print(f"[Analyze] Retrying errored units from: {results_path}", file=sys.stderr)
+            else:
+                print(f"[Analyze] Already complete: {results_path}", file=sys.stderr)
+                print("[Analyze] Use --fresh to reanalyze all units from scratch.", file=sys.stderr)
+                print("[Analyze] Use --retry-errors to reprocess only errored units.", file=sys.stderr)
 
-            experiment = read_json(results_path)
+                experiment = read_json(results_path)
 
-            metrics_data = experiment.get("metrics", {})
-            metrics = AnalysisMetrics(
-                total=metrics_data.get("total", 0),
-                vulnerable=metrics_data.get("vulnerable", 0),
-                bypassable=metrics_data.get("bypassable", 0),
-                inconclusive=metrics_data.get("inconclusive", 0),
-                protected=metrics_data.get("protected", 0),
-                safe=metrics_data.get("safe", 0),
-                errors=metrics_data.get("errors", 0),
-            )
+                metrics_data = experiment.get("metrics", {})
+                metrics = AnalysisMetrics(
+                    total=metrics_data.get("total", 0),
+                    vulnerable=metrics_data.get("vulnerable", 0),
+                    bypassable=metrics_data.get("bypassable", 0),
+                    inconclusive=metrics_data.get("inconclusive", 0),
+                    protected=metrics_data.get("protected", 0),
+                    safe=metrics_data.get("safe", 0),
+                    errors=metrics_data.get("errors", 0),
+                )
 
-            return AnalyzeResult(
-                results_path=results_path,
-                metrics=metrics,
-                usage=UsageInfo(),
-            )
+                return AnalyzeResult(
+                    results_path=results_path,
+                    metrics=metrics,
+                    usage=UsageInfo(),
+                )
 
     # Reset tracking for this analysis run
     tracking.reset_tracking()
@@ -179,6 +192,9 @@ def run_analysis(
             cp = read_json(checkpoint_path)
             results = cp.get("results", [])
             code_by_route = cp.get("code_by_route", {})
+            if retry_errors:
+                # Filter out errored results so they get reprocessed
+                results = [r for r in results if r.get("verdict") != "ERROR"]
             completed_ids = {r["unit_id"] for r in results}
             # Recount from checkpoint
             for r in results:

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -9,6 +9,7 @@ Stage 2 verification is handled separately by ``core.verifier``.
 
 import json
 import os
+import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -108,12 +109,14 @@ def run_analysis(
         if os.path.exists(results_path) and not has_checkpoint:
             # Check if there are errored units worth retrying
             experiment = read_json(results_path)
-            error_count = experiment.get("metrics", {}).get("errors", 0)
+            error_count = sum(
+                1 for r in experiment.get("results", [])
+                if r.get("verdict") == "ERROR"
+            )
 
             if error_count > 0 and not skip_errors:
                 # Copy completed results to checkpoint path so the resume
                 # logic re-processes errored units.
-                import shutil
                 shutil.copy2(results_path, checkpoint_path)
                 print(f"[Analyze] Retrying {error_count} errored units from: {results_path}", file=sys.stderr)
             else:

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -75,7 +75,7 @@ def enhance_dataset(
                 if u.get(context_key, {}).get("error")
             )
 
-            if error_count > 0 and not skip_errors:
+            if error_count > 0 and not skip_errors and checkpoint_path:
                 # Copy completed output to checkpoint path so the existing
                 # checkpoint resume logic re-processes errored units.
                 shutil.copy2(output_path, checkpoint_path)

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -125,8 +125,10 @@ def enhance_dataset(
         try:
             cp_data = read_json(checkpoint_path)
             for cp_unit in cp_data.get("units", []):
-                if cp_unit.get("agent_context") and not cp_unit["agent_context"].get("error"):
-                    resumed_count += 1
+                if cp_unit.get("agent_context"):
+                    has_error = cp_unit["agent_context"].get("error")
+                    if not has_error or skip_errors:
+                        resumed_count += 1
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -151,6 +153,7 @@ def enhance_dataset(
             repo_path=repo_path,
             checkpoint_path=checkpoint_path,
             progress_callback=_on_unit_done,
+            skip_errors=skip_errors,
         )
     elif mode == "single-shot":
         enhanced = enhancer.enhance_dataset(

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -36,6 +36,10 @@ def enhance_dataset(
         repo_path: Path to the repository (required for agentic mode).
         mode: "agentic" (thorough, tool-use) or "single-shot" (fast, cheaper).
         checkpoint_path: Path to save/resume checkpoint (agentic mode only).
+        fresh: If True, delete existing checkpoint and reprocess all units.
+        skip_errors: If True, skip errored units instead of retrying them.
+            By default, errored units are automatically retried on re-run.
+            Only supported in agentic mode.
         model: "sonnet" (default, cost-effective).
 
     Returns:

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -23,7 +23,7 @@ def enhance_dataset(
     mode: str = "agentic",
     checkpoint_path: str | None = None,
     fresh: bool = False,
-    retry_errors: bool = False,
+    skip_errors: bool = False,
     model: str = "sonnet",
 ) -> EnhanceResult:
     """Enhance a parsed dataset with security context.
@@ -48,10 +48,10 @@ def enhance_dataset(
         checkpoint_path = os.path.splitext(output_path)[0] + "_checkpoint.json"
 
     # Validate flag combinations
-    if fresh and retry_errors:
-        raise ValueError("Cannot use both --fresh and --retry-errors")
-    if retry_errors and mode != "agentic":
-        raise ValueError("--retry-errors is only supported in agentic mode")
+    if fresh and skip_errors:
+        raise ValueError("Cannot use both --fresh and --skip-errors")
+    if skip_errors and mode != "agentic":
+        raise ValueError("--skip-errors is only supported in agentic mode")
 
     # If fresh, delete existing checkpoint and output
     if fresh:
@@ -59,30 +59,31 @@ def enhance_dataset(
             os.remove(checkpoint_path)
     else:
         # If output already exists and no checkpoint (i.e. previous run completed),
-        # skip enhancement entirely — use --fresh to force a rerun.
+        # check for errored units to retry.
         has_checkpoint = checkpoint_path and os.path.exists(checkpoint_path)
         if os.path.exists(output_path) and not has_checkpoint:
-            if retry_errors:
+            # Check if there are errored units worth retrying
+            enhanced = read_json(output_path)
+            context_key = "agent_context" if mode == "agentic" else "llm_context"
+            error_count = sum(
+                1 for u in enhanced.get("units", [])
+                if u.get(context_key, {}).get("error")
+            )
+
+            if error_count > 0 and not skip_errors:
                 # Copy completed output to checkpoint path so the existing
                 # checkpoint resume logic re-processes errored units.
                 import shutil
                 shutil.copy2(output_path, checkpoint_path)
-                print(f"[Enhance] Retrying errored units from: {output_path}", file=sys.stderr)
+                print(f"[Enhance] Retrying {error_count} errored units from: {output_path}", file=sys.stderr)
             else:
                 print(f"[Enhance] Already complete: {output_path}", file=sys.stderr)
                 print("[Enhance] Use --fresh to reprocess all units from scratch.", file=sys.stderr)
-                print("[Enhance] Use --retry-errors to reprocess only errored units.", file=sys.stderr)
 
-                # Load the existing output to build the result
-                enhanced = read_json(output_path)
-
-                context_key = "agent_context" if mode == "agentic" else "llm_context"
                 classifications = {}
-                error_count = 0
                 for unit in enhanced.get("units", []):
                     ctx = unit.get(context_key, {})
                     if ctx.get("error"):
-                        error_count += 1
                         continue
                     cls = ctx.get("security_classification", "unknown")
                     classifications[cls] = classifications.get(cls, 0) + 1

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -7,6 +7,7 @@ for both agentic and single-shot enhancement modes.
 
 import json
 import os
+import shutil
 import sys
 
 from core.schemas import EnhanceResult, UsageInfo
@@ -73,7 +74,6 @@ def enhance_dataset(
             if error_count > 0 and not skip_errors:
                 # Copy completed output to checkpoint path so the existing
                 # checkpoint resume logic re-processes errored units.
-                import shutil
                 shutil.copy2(output_path, checkpoint_path)
                 print(f"[Enhance] Retrying {error_count} errored units from: {output_path}", file=sys.stderr)
             else:

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -23,6 +23,7 @@ def enhance_dataset(
     mode: str = "agentic",
     checkpoint_path: str | None = None,
     fresh: bool = False,
+    retry_errors: bool = False,
     model: str = "sonnet",
 ) -> EnhanceResult:
     """Enhance a parsed dataset with security context.
@@ -46,6 +47,12 @@ def enhance_dataset(
     if checkpoint_path is None and mode == "agentic":
         checkpoint_path = os.path.splitext(output_path)[0] + "_checkpoint.json"
 
+    # Validate flag combinations
+    if fresh and retry_errors:
+        raise ValueError("Cannot use both --fresh and --retry-errors")
+    if retry_errors and mode != "agentic":
+        raise ValueError("--retry-errors is only supported in agentic mode")
+
     # If fresh, delete existing checkpoint and output
     if fresh:
         if checkpoint_path and os.path.exists(checkpoint_path):
@@ -55,30 +62,38 @@ def enhance_dataset(
         # skip enhancement entirely — use --fresh to force a rerun.
         has_checkpoint = checkpoint_path and os.path.exists(checkpoint_path)
         if os.path.exists(output_path) and not has_checkpoint:
-            print(f"[Enhance] Already complete: {output_path}", file=sys.stderr)
-            print("[Enhance] Use --fresh to reprocess all units from scratch.", file=sys.stderr)
+            if retry_errors:
+                # Copy completed output to checkpoint path so the existing
+                # checkpoint resume logic re-processes errored units.
+                import shutil
+                shutil.copy2(output_path, checkpoint_path)
+                print(f"[Enhance] Retrying errored units from: {output_path}", file=sys.stderr)
+            else:
+                print(f"[Enhance] Already complete: {output_path}", file=sys.stderr)
+                print("[Enhance] Use --fresh to reprocess all units from scratch.", file=sys.stderr)
+                print("[Enhance] Use --retry-errors to reprocess only errored units.", file=sys.stderr)
 
-            # Load the existing output to build the result
-            enhanced = read_json(output_path)
+                # Load the existing output to build the result
+                enhanced = read_json(output_path)
 
-            context_key = "agent_context" if mode == "agentic" else "llm_context"
-            classifications = {}
-            error_count = 0
-            for unit in enhanced.get("units", []):
-                ctx = unit.get(context_key, {})
-                if ctx.get("error"):
-                    error_count += 1
-                    continue
-                cls = ctx.get("security_classification", "unknown")
-                classifications[cls] = classifications.get(cls, 0) + 1
+                context_key = "agent_context" if mode == "agentic" else "llm_context"
+                classifications = {}
+                error_count = 0
+                for unit in enhanced.get("units", []):
+                    ctx = unit.get(context_key, {})
+                    if ctx.get("error"):
+                        error_count += 1
+                        continue
+                    cls = ctx.get("security_classification", "unknown")
+                    classifications[cls] = classifications.get(cls, 0) + 1
 
-            return EnhanceResult(
-                enhanced_dataset_path=output_path,
-                units_enhanced=len(enhanced.get("units", [])) - error_count,
-                error_count=error_count,
-                classifications=classifications,
-                usage=UsageInfo(),
-            )
+                return EnhanceResult(
+                    enhanced_dataset_path=output_path,
+                    units_enhanced=len(enhanced.get("units", [])) - error_count,
+                    error_count=error_count,
+                    classifications=classifications,
+                    usage=UsageInfo(),
+                )
 
     model_id = "claude-sonnet-4-20250514" if model == "sonnet" else "claude-opus-4-6"
     print(f"[Enhance] Mode: {mode}", file=sys.stderr)

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -139,7 +139,7 @@ def cmd_enhance(args):
                 repo_path=args.repo_path,
                 mode=args.mode,
                 fresh=args.fresh,
-                retry_errors=args.retry_errors,
+                skip_errors=args.skip_errors,
             )
 
             ctx.summary = {
@@ -189,7 +189,7 @@ def cmd_analyze(args):
                 model=args.model,
                 exploitable_only=args.exploitable_only,
                 fresh=args.fresh,
-                retry_errors=args.retry_errors,
+                skip_errors=args.skip_errors,
             )
 
             ctx.summary = {
@@ -541,8 +541,8 @@ def main():
     enhance_p.add_argument("--output", "-o", help="Output path for enhanced dataset (default: {input}_enhanced.json)")
     enhance_p.add_argument("--fresh", action="store_true",
                            help="Ignore checkpoint and reprocess all units from scratch")
-    enhance_p.add_argument("--retry-errors", action="store_true",
-                           help="Re-process only errored units from a previous completed run")
+    enhance_p.add_argument("--skip-errors", action="store_true",
+                           help="Skip errored units instead of retrying them")
     enhance_p.add_argument(
         "--mode",
         choices=["agentic", "single-shot"],
@@ -567,8 +567,8 @@ def main():
     analyze_p.add_argument("--model", choices=["opus", "sonnet"], default="opus", help="Model (default: opus)")
     analyze_p.add_argument("--fresh", action="store_true",
                            help="Ignore checkpoint and reanalyze all units from scratch")
-    analyze_p.add_argument("--retry-errors", action="store_true",
-                           help="Re-process only errored units from a previous completed run")
+    analyze_p.add_argument("--skip-errors", action="store_true",
+                           help="Skip errored units instead of retrying them")
     analyze_p.set_defaults(func=cmd_analyze)
 
     # ---------------------------------------------------------------

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -139,6 +139,7 @@ def cmd_enhance(args):
                 repo_path=args.repo_path,
                 mode=args.mode,
                 fresh=args.fresh,
+                retry_errors=args.retry_errors,
             )
 
             ctx.summary = {
@@ -188,6 +189,7 @@ def cmd_analyze(args):
                 model=args.model,
                 exploitable_only=args.exploitable_only,
                 fresh=args.fresh,
+                retry_errors=args.retry_errors,
             )
 
             ctx.summary = {
@@ -539,6 +541,8 @@ def main():
     enhance_p.add_argument("--output", "-o", help="Output path for enhanced dataset (default: {input}_enhanced.json)")
     enhance_p.add_argument("--fresh", action="store_true",
                            help="Ignore checkpoint and reprocess all units from scratch")
+    enhance_p.add_argument("--retry-errors", action="store_true",
+                           help="Re-process only errored units from a previous completed run")
     enhance_p.add_argument(
         "--mode",
         choices=["agentic", "single-shot"],
@@ -563,6 +567,8 @@ def main():
     analyze_p.add_argument("--model", choices=["opus", "sonnet"], default="opus", help="Model (default: opus)")
     analyze_p.add_argument("--fresh", action="store_true",
                            help="Ignore checkpoint and reanalyze all units from scratch")
+    analyze_p.add_argument("--retry-errors", action="store_true",
+                           help="Re-process only errored units from a previous completed run")
     analyze_p.set_defaults(func=cmd_analyze)
 
     # ---------------------------------------------------------------

--- a/libs/openant-core/tests/test_skip_errors.py
+++ b/libs/openant-core/tests/test_skip_errors.py
@@ -1,0 +1,391 @@
+"""Tests for --skip-errors flag: auto-retry errored units on re-run."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Ensure project root is on path
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.utils import atomic_write_json
+from utilities.file_io import read_json, write_json
+
+import core.analyzer as analyzer_mod
+import core.enhancer as enhancer_mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset(tmp_path, num_units=5):
+    """Create a minimal dataset for tests."""
+    units = []
+    for i in range(num_units):
+        units.append({
+            "id": f"unit_{i}",
+            "unit_type": "route_handler",
+            "code": {
+                "primary_code": f"function handler{i}() {{ return db.query(req.params.id); }}",
+                "primary_origin": {
+                    "file_path": f"src/handler{i}.js",
+                    "function_name": f"handler{i}",
+                },
+            },
+            "metadata": {"direct_calls": [], "direct_callers": []},
+        })
+
+    dataset = {"units": units, "metadata": {}}
+    dataset_path = str(tmp_path / "dataset.json")
+    write_json(dataset_path, dataset)
+
+    return dataset_path
+
+
+def _mock_analyze_unit(client, unit, use_multifile=True, json_corrector=None, app_context=None):
+    uid = unit.get("id", "unknown")
+    return {
+        "unit_id": uid,
+        "route_key": f"src/{uid}.js:{uid}",
+        "finding": "safe",
+        "verdict": "SAFE",
+        "reasoning": "No vulnerability found",
+    }
+
+
+def _mock_tracker():
+    return MagicMock(get_totals=lambda: {"total_cost_usd": 0.0})
+
+
+def _analyze_patches(mock_au=None):
+    """Return context managers for mocking analyze dependencies."""
+    side_effect = mock_au or _mock_analyze_unit
+    return [
+        patch.object(analyzer_mod, "AnthropicClient"),
+        patch.object(analyzer_mod, "JSONCorrector"),
+        patch.object(analyzer_mod, "get_global_tracker", return_value=_mock_tracker()),
+        patch.object(analyzer_mod, "analyze_unit", side_effect=side_effect),
+        patch.dict("sys.modules", {"utilities.stage1_consistency": None}),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Enhance: auto-retry errored units
+# ---------------------------------------------------------------------------
+
+
+class TestEnhanceAutoRetryErrors:
+
+    def test_completed_run_with_errors_retries_by_default(self, tmp_path):
+        """Completed enhance output with errors -> auto-retries errored units."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_path = str(tmp_path / "dataset_enhanced.json")
+        ao_path = str(tmp_path / "analyzer_output.json")
+        write_json(ao_path, {"functions": {}, "files": {}})
+
+        # Create a "completed" output with one errored unit
+        dataset = read_json(dataset_path)
+        for i, unit in enumerate(dataset["units"]):
+            if i == 1:
+                unit["agent_context"] = {
+                    "error": "API timeout",
+                    "security_classification": "neutral",
+                    "confidence": 0.0,
+                }
+            else:
+                unit["agent_context"] = {
+                    "security_classification": "neutral",
+                    "confidence": 0.8,
+                    "include_functions": [],
+                }
+        write_json(output_path, dataset)
+
+        # Call enhance_dataset — should copy output to checkpoint and fall through
+        # We mock the actual enhancement to avoid LLM calls
+        # Lazy imports in enhancer.py require patching at source modules
+        mock_enhancer_instance = MagicMock()
+        mock_enhancer_instance.enhance_dataset_agentic.return_value = dataset
+
+        with patch("utilities.llm_client.AnthropicClient", return_value=MagicMock()), \
+             patch("utilities.llm_client.get_global_tracker", return_value=_mock_tracker()), \
+             patch("utilities.context_enhancer.ContextEnhancer", return_value=mock_enhancer_instance), \
+             patch("core.progress.ProgressReporter", return_value=MagicMock()), \
+             patch("core.utils.atomic_write_json"):
+            result = enhancer_mod.enhance_dataset(
+                dataset_path=dataset_path,
+                output_path=output_path,
+                analyzer_output_path=ao_path,
+                repo_path=str(tmp_path),
+            )
+
+        # Should have called enhance_dataset_agentic (not returned early)
+        mock_enhancer_instance.enhance_dataset_agentic.assert_called_once()
+
+    def test_completed_run_with_errors_skips_with_flag(self, tmp_path):
+        """Completed output with errors + skip_errors=True -> returns early."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_path = str(tmp_path / "dataset_enhanced.json")
+
+        # Create a "completed" output with one errored unit
+        dataset = read_json(dataset_path)
+        for i, unit in enumerate(dataset["units"]):
+            if i == 1:
+                unit["agent_context"] = {
+                    "error": "API timeout",
+                    "security_classification": "neutral",
+                    "confidence": 0.0,
+                }
+            else:
+                unit["agent_context"] = {
+                    "security_classification": "neutral",
+                    "confidence": 0.8,
+                }
+        write_json(output_path, dataset)
+
+        result = enhancer_mod.enhance_dataset(
+            dataset_path=dataset_path,
+            output_path=output_path,
+            skip_errors=True,
+        )
+
+        # Should return early with cached results (no LLM calls)
+        assert result.error_count == 1
+        assert result.units_enhanced == 2
+        assert result.usage.total_cost_usd == 0.0
+
+    def test_completed_run_no_errors_returns_early(self, tmp_path):
+        """Completed output with zero errors -> returns early (no retry needed)."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_path = str(tmp_path / "dataset_enhanced.json")
+
+        # Create a "completed" output with no errors
+        dataset = read_json(dataset_path)
+        for unit in dataset["units"]:
+            unit["agent_context"] = {
+                "security_classification": "neutral",
+                "confidence": 0.8,
+            }
+        write_json(output_path, dataset)
+
+        result = enhancer_mod.enhance_dataset(
+            dataset_path=dataset_path,
+            output_path=output_path,
+        )
+
+        # Should return early — no errors to retry
+        assert result.error_count == 0
+        assert result.usage.total_cost_usd == 0.0
+
+    def test_fresh_and_skip_errors_raises(self, tmp_path):
+        """--fresh + --skip-errors -> ValueError."""
+        dataset_path = _make_dataset(tmp_path, num_units=1)
+        output_path = str(tmp_path / "dataset_enhanced.json")
+
+        with pytest.raises(ValueError, match="Cannot use both"):
+            enhancer_mod.enhance_dataset(
+                dataset_path=dataset_path,
+                output_path=output_path,
+                fresh=True,
+                skip_errors=True,
+            )
+
+    def test_skip_errors_single_shot_raises(self, tmp_path):
+        """--skip-errors + single-shot mode -> ValueError."""
+        dataset_path = _make_dataset(tmp_path, num_units=1)
+        output_path = str(tmp_path / "dataset_enhanced.json")
+
+        with pytest.raises(ValueError, match="only supported in agentic mode"):
+            enhancer_mod.enhance_dataset(
+                dataset_path=dataset_path,
+                output_path=output_path,
+                mode="single-shot",
+                skip_errors=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Analyze: auto-retry errored units
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeAutoRetryErrors:
+
+    def test_completed_run_with_errors_retries_by_default(self, tmp_path):
+        """Completed results.json with errors -> auto-retries errored units."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_dir = str(tmp_path / "output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Create a "completed" results.json with one errored unit
+        results_path = os.path.join(output_dir, "results.json")
+        experiment = {
+            "dataset": "test.json",
+            "model": "claude-opus-4-6",
+            "metrics": {"total": 3, "safe": 2, "errors": 1,
+                        "vulnerable": 0, "bypassable": 0,
+                        "inconclusive": 0, "protected": 0},
+            "results": [
+                {"unit_id": "unit_0", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_1", "finding": "error", "verdict": "ERROR", "error": "timeout"},
+                {"unit_id": "unit_2", "finding": "safe", "verdict": "SAFE"},
+            ],
+            "code_by_route": {},
+        }
+        write_json(results_path, experiment)
+
+        patches = _analyze_patches()
+        with patches[0], patches[1], patches[2], \
+             patches[3] as mock_au, patches[4]:
+            result = analyzer_mod.run_analysis(
+                dataset_path=dataset_path,
+                output_dir=output_dir,
+            )
+
+        # Should have retried only the errored unit (unit_1)
+        # The checkpoint resume loads 2 successful results, skips them,
+        # and processes only unit_1
+        assert mock_au.call_count == 1
+
+    def test_completed_run_with_errors_skips_with_flag(self, tmp_path):
+        """Completed results with errors + skip_errors=True -> returns early."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_dir = str(tmp_path / "output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        results_path = os.path.join(output_dir, "results.json")
+        experiment = {
+            "dataset": "test.json",
+            "model": "claude-opus-4-6",
+            "metrics": {"total": 3, "safe": 2, "errors": 1,
+                        "vulnerable": 0, "bypassable": 0,
+                        "inconclusive": 0, "protected": 0},
+            "results": [
+                {"unit_id": "unit_0", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_1", "finding": "error", "verdict": "ERROR", "error": "timeout"},
+                {"unit_id": "unit_2", "finding": "safe", "verdict": "SAFE"},
+            ],
+            "code_by_route": {},
+        }
+        write_json(results_path, experiment)
+
+        result = analyzer_mod.run_analysis(
+            dataset_path=dataset_path,
+            output_dir=output_dir,
+            skip_errors=True,
+        )
+
+        # Should return early with cached results
+        assert result.metrics.errors == 1
+        assert result.usage.total_cost_usd == 0.0
+
+    def test_completed_run_no_errors_returns_early(self, tmp_path):
+        """Completed results with zero errors -> returns early."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_dir = str(tmp_path / "output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        results_path = os.path.join(output_dir, "results.json")
+        experiment = {
+            "dataset": "test.json",
+            "model": "claude-opus-4-6",
+            "metrics": {"total": 3, "safe": 3, "errors": 0,
+                        "vulnerable": 0, "bypassable": 0,
+                        "inconclusive": 0, "protected": 0},
+            "results": [
+                {"unit_id": "unit_0", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_1", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_2", "finding": "safe", "verdict": "SAFE"},
+            ],
+            "code_by_route": {},
+        }
+        write_json(results_path, experiment)
+
+        result = analyzer_mod.run_analysis(
+            dataset_path=dataset_path,
+            output_dir=output_dir,
+        )
+
+        # Should return early — no errors to retry
+        assert result.metrics.errors == 0
+        assert result.usage.total_cost_usd == 0.0
+
+    def test_fresh_and_skip_errors_raises(self, tmp_path):
+        """--fresh + --skip-errors -> ValueError."""
+        dataset_path = _make_dataset(tmp_path, num_units=1)
+        output_dir = str(tmp_path / "output")
+
+        with pytest.raises(ValueError, match="Cannot use both"):
+            analyzer_mod.run_analysis(
+                dataset_path=dataset_path,
+                output_dir=output_dir,
+                fresh=True,
+                skip_errors=True,
+            )
+
+    def test_checkpoint_resume_filters_errors_by_default(self, tmp_path):
+        """Checkpoint resume excludes errored results from completed_ids."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_dir = str(tmp_path / "output")
+        checkpoint_path = os.path.join(output_dir, "analyze_checkpoint.json")
+
+        # Create a checkpoint with one errored unit
+        os.makedirs(output_dir, exist_ok=True)
+        atomic_write_json(checkpoint_path, {
+            "results": [
+                {"unit_id": "unit_0", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_1", "finding": "error", "verdict": "ERROR", "error": "timeout"},
+            ],
+            "code_by_route": {},
+            "counts": {"safe": 1, "errors": 1},
+        })
+
+        patches = _analyze_patches()
+        with patches[0], patches[1], patches[2], \
+             patches[3] as mock_au, patches[4]:
+            result = analyzer_mod.run_analysis(
+                dataset_path=dataset_path,
+                output_dir=output_dir,
+                checkpoint_path=checkpoint_path,
+            )
+
+        # unit_0 is done, unit_1 errored (retried), unit_2 is new
+        # So 2 units should be processed
+        assert mock_au.call_count == 2
+
+    def test_checkpoint_resume_keeps_errors_with_skip_flag(self, tmp_path):
+        """Checkpoint resume with skip_errors keeps errored results in completed_ids."""
+        dataset_path = _make_dataset(tmp_path, num_units=3)
+        output_dir = str(tmp_path / "output")
+        checkpoint_path = os.path.join(output_dir, "analyze_checkpoint.json")
+
+        # Create a checkpoint with one errored unit
+        os.makedirs(output_dir, exist_ok=True)
+        atomic_write_json(checkpoint_path, {
+            "results": [
+                {"unit_id": "unit_0", "finding": "safe", "verdict": "SAFE"},
+                {"unit_id": "unit_1", "finding": "error", "verdict": "ERROR", "error": "timeout"},
+            ],
+            "code_by_route": {},
+            "counts": {"safe": 1, "errors": 1},
+        })
+
+        patches = _analyze_patches()
+        with patches[0], patches[1], patches[2], \
+             patches[3] as mock_au, patches[4]:
+            result = analyzer_mod.run_analysis(
+                dataset_path=dataset_path,
+                output_dir=output_dir,
+                checkpoint_path=checkpoint_path,
+                skip_errors=True,
+            )
+
+        # unit_0 done, unit_1 errored but SKIPPED, unit_2 is new
+        # Only 1 unit should be processed
+        assert mock_au.call_count == 1

--- a/libs/openant-core/tests/test_skip_errors.py
+++ b/libs/openant-core/tests/test_skip_errors.py
@@ -128,6 +128,18 @@ class TestEnhanceAutoRetryErrors:
         # Should have called enhance_dataset_agentic (not returned early)
         mock_enhancer_instance.enhance_dataset_agentic.assert_called_once()
 
+        # Verify checkpoint path was passed through
+        call_kwargs = mock_enhancer_instance.enhance_dataset_agentic.call_args
+        checkpoint_path = str(tmp_path / "dataset_enhanced_checkpoint.json")
+        assert call_kwargs.kwargs.get("checkpoint_path") == checkpoint_path
+
+        # Verify the checkpoint file was created (copied from output)
+        # and contains the errored unit
+        cp_data = read_json(checkpoint_path)
+        errored = [u for u in cp_data["units"] if u.get("agent_context", {}).get("error")]
+        assert len(errored) == 1
+        assert errored[0]["id"] == "unit_1"
+
     def test_completed_run_with_errors_skips_with_flag(self, tmp_path):
         """Completed output with errors + skip_errors=True -> returns early."""
         dataset_path = _make_dataset(tmp_path, num_units=3)

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -343,6 +343,7 @@ class ContextEnhancer:
         verbose: bool = False,
         checkpoint_path: str = None,
         progress_callback: Optional[Callable] = None,
+        skip_errors: bool = False,
     ) -> dict:
         """
         Enhance all units using agentic approach with tool use.
@@ -362,6 +363,7 @@ class ContextEnhancer:
             checkpoint_path: Path to save/load checkpoint file (enables resume)
             progress_callback: Optional callback(unit_id, classification, unit_elapsed)
                 called after each unit completes.
+            skip_errors: If True, skip errored units on resume instead of retrying them.
 
         Returns:
             Enhanced dataset with agent_context field
@@ -380,8 +382,10 @@ class ContextEnhancer:
 
                 # Build set of already-processed unit IDs
                 for cp_unit in checkpoint_data.get("units", []):
-                    if cp_unit.get("agent_context") and not cp_unit["agent_context"].get("error"):
-                        processed_ids.add(cp_unit.get("id"))
+                    if cp_unit.get("agent_context"):
+                        has_error = cp_unit["agent_context"].get("error")
+                        if not has_error or skip_errors:
+                            processed_ids.add(cp_unit.get("id"))
 
                 # Restore units from checkpoint
                 cp_units_by_id = {u.get("id"): u for u in checkpoint_data.get("units", [])}


### PR DESCRIPTION
## Summary

- Enhance and analyze commands now automatically retry errored units on the next run, instead of treating completed-with-errors as fully done
- Adds `--skip-errors` flag to opt out and skip errored units instead of retrying them
- Fixes analyze's checkpoint resume to filter out errored results by default (matching enhance's existing behavior)
- Works by copying the completed output to the checkpoint path when errors are detected, letting the existing checkpoint resume logic handle reprocessing

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Completed run with errors, re-run | Skips (returns cached) | Retries errored units |
| Completed run with errors, `--skip-errors` | N/A | Skips (returns cached) |
| Partial run (checkpoint), resume | Enhance retries errors, analyze skips them | Both retry errors |
| `--fresh` | Reprocesses everything | Unchanged |

## Test plan

- [ ] Run enhance, inject `"error"` into one unit's `agent_context` in the output, re-run — verify only the errored unit is reprocessed
- [ ] Same for analyze: inject `{"verdict": "ERROR"}` into results.json, re-run
- [ ] Verify `--skip-errors` skips errored units and returns cached results
- [ ] Verify `--skip-errors --fresh` is rejected for both commands
- [ ] Verify runs with zero errors still return early as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)