### PR TITLE
fix: default parse --level to reachable

### DIFF
--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -31,7 +31,7 @@ var (
 func init() {
 	parseCmd.Flags().StringVarP(&parseOutput, "output", "o", "", "Output directory (default: project scan dir)")
 	parseCmd.Flags().StringVarP(&parseLanguage, "language", "l", "", "Language: python, javascript, go, c, ruby, php, auto")
-	parseCmd.Flags().StringVar(&parseLevel, "level", "all", "Processing level: all, reachable, codeql, exploitable")
+	parseCmd.Flags().StringVar(&parseLevel, "level", "reachable", "Processing level: all, reachable, codeql, exploitable")
 }
 
 func runParse(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary
- The Go CLI `parse` command defaulted `--level` to `"all"`, skipping reachability analysis entirely
- The `scan` command and the Python CLI both default to `"reachable"`
- Changed the default in `parse.go` to `"reachable"` so reachability filtering runs by default when using `openant parse`

## Test plan
- [x] Run `openant parse` without `--level` and verify output shows `Processing Level: reachable`
- [x] Run `openant parse --level all` and verify it still allows overriding to `all`
- [ ] Run `openant scan` and verify parse step still defaults to `reachable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)