### PR TITLE
feat: parallelize LLM calls with --concurrency flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ apps/openant-cli/bin/
 .build/
 docs/
 .worktrees/
+.claude/

--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -33,6 +33,7 @@ var (
 	analyzeModel          string
 	analyzeFresh          bool
 	analyzeSkipErrors     bool
+	analyzeConcurrency    int
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	analyzeCmd.Flags().StringVar(&analyzeModel, "model", "opus", "Model: opus or sonnet")
 	analyzeCmd.Flags().BoolVar(&analyzeFresh, "fresh", false, "Ignore checkpoint and reanalyze all units from scratch")
 	analyzeCmd.Flags().BoolVar(&analyzeSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them (errors are retried by default)")
+	analyzeCmd.Flags().IntVarP(&analyzeConcurrency, "concurrency", "j", 4, "Number of concurrent LLM calls (default: 4)")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {
@@ -105,6 +107,9 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 	}
 	if analyzeSkipErrors {
 		pyArgs = append(pyArgs, "--skip-errors")
+	}
+	if analyzeConcurrency != 4 {
+		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", analyzeConcurrency))
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -51,6 +51,11 @@ func init() {
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {
+	if analyzeConcurrency < 1 {
+		fmt.Fprintln(os.Stderr, "Error: --concurrency must be >= 1")
+		os.Exit(1)
+	}
+
 	datasetPath, ctx, err := resolveFileArg(args, "dataset_enhanced.json")
 	if err != nil {
 		output.PrintError(err.Error())
@@ -108,9 +113,7 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 	if analyzeSkipErrors {
 		pyArgs = append(pyArgs, "--skip-errors")
 	}
-	if analyzeConcurrency != 4 {
-		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", analyzeConcurrency))
-	}
+	pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", analyzeConcurrency))
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/knostic/open-ant-cli/internal/output"
@@ -29,6 +30,7 @@ var (
 	enhanceMode           string
 	enhanceFresh          bool
 	enhanceSkipErrors     bool
+	enhanceConcurrency    int
 )
 
 func init() {
@@ -38,6 +40,7 @@ func init() {
 	enhanceCmd.Flags().StringVar(&enhanceMode, "mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
 	enhanceCmd.Flags().BoolVar(&enhanceFresh, "fresh", false, "Ignore checkpoint and reprocess all units from scratch")
 	enhanceCmd.Flags().BoolVar(&enhanceSkipErrors, "skip-errors", false, "Skip errored units instead of retrying them (errors are retried by default)")
+	enhanceCmd.Flags().IntVarP(&enhanceConcurrency, "concurrency", "j", 4, "Number of concurrent LLM calls (default: 4)")
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {
@@ -84,6 +87,9 @@ func runEnhance(cmd *cobra.Command, args []string) {
 	}
 	if enhanceSkipErrors {
 		pyArgs = append(pyArgs, "--skip-errors")
+	}
+	if enhanceConcurrency != 4 {
+		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", enhanceConcurrency))
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -44,6 +44,11 @@ func init() {
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {
+	if enhanceConcurrency < 1 {
+		fmt.Fprintln(os.Stderr, "Error: --concurrency must be >= 1")
+		os.Exit(1)
+	}
+
 	datasetPath, ctx, err := resolveFileArg(args, "dataset.json")
 	if err != nil {
 		output.PrintError(err.Error())
@@ -88,9 +93,7 @@ func runEnhance(cmd *cobra.Command, args []string) {
 	if enhanceSkipErrors {
 		pyArgs = append(pyArgs, "--skip-errors")
 	}
-	if enhanceConcurrency != 4 {
-		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", enhanceConcurrency))
-	}
+	pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", enhanceConcurrency))
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {

--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -59,6 +59,11 @@ func init() {
 }
 
 func runScan(cmd *cobra.Command, args []string) {
+	if scanConcurrency < 1 {
+		fmt.Fprintln(os.Stderr, "Error: --concurrency must be >= 1")
+		os.Exit(1)
+	}
+
 	repoPath, ctx, err := resolveRepoArg(args)
 	if err != nil {
 		output.PrintError(err.Error())
@@ -122,9 +127,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	if scanFresh {
 		pyArgs = append(pyArgs, "--fresh")
 	}
-	if scanConcurrency != 4 {
-		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", scanConcurrency))
-	}
+	pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", scanConcurrency))
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {

--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -39,6 +39,7 @@ var (
 	scanLimit       int
 	scanModel       string
 	scanFresh       bool
+	scanConcurrency int
 )
 
 func init() {
@@ -54,6 +55,7 @@ func init() {
 	scanCmd.Flags().IntVar(&scanLimit, "limit", 0, "Max units to analyze (0 = no limit)")
 	scanCmd.Flags().StringVar(&scanModel, "model", "opus", "Model: opus or sonnet")
 	scanCmd.Flags().BoolVar(&scanFresh, "fresh", false, "Ignore previous progress and rerun all steps from scratch")
+	scanCmd.Flags().IntVarP(&scanConcurrency, "concurrency", "j", 4, "Number of concurrent LLM calls (default: 4)")
 }
 
 func runScan(cmd *cobra.Command, args []string) {
@@ -119,6 +121,9 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 	if scanFresh {
 		pyArgs = append(pyArgs, "--fresh")
+	}
+	if scanConcurrency != 4 {
+		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", scanConcurrency))
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/verify.go
+++ b/apps/openant-cli/cmd/verify.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/knostic/open-ant-cli/internal/output"
@@ -30,6 +31,7 @@ var (
 	verifyAppContext     string
 	verifyRepoPath       string
 	verifyFresh          bool
+	verifyConcurrency    int
 )
 
 func init() {
@@ -38,6 +40,7 @@ func init() {
 	verifyCmd.Flags().StringVar(&verifyAppContext, "app-context", "", "Path to application_context.json")
 	verifyCmd.Flags().StringVar(&verifyRepoPath, "repo-path", "", "Path to the repository")
 	verifyCmd.Flags().BoolVar(&verifyFresh, "fresh", false, "Ignore checkpoint and reverify all findings from scratch")
+	verifyCmd.Flags().IntVarP(&verifyConcurrency, "concurrency", "j", 4, "Number of concurrent LLM calls (default: 4)")
 }
 
 func runVerify(cmd *cobra.Command, args []string) {
@@ -82,6 +85,9 @@ func runVerify(cmd *cobra.Command, args []string) {
 	}
 	if verifyFresh {
 		pyArgs = append(pyArgs, "--fresh")
+	}
+	if verifyConcurrency != 4 {
+		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", verifyConcurrency))
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/verify.go
+++ b/apps/openant-cli/cmd/verify.go
@@ -44,6 +44,11 @@ func init() {
 }
 
 func runVerify(cmd *cobra.Command, args []string) {
+	if verifyConcurrency < 1 {
+		fmt.Fprintln(os.Stderr, "Error: --concurrency must be >= 1")
+		os.Exit(1)
+	}
+
 	resultsPath, ctx, err := resolveFileArg(args, "results.json")
 	if err != nil {
 		output.PrintError(err.Error())
@@ -86,9 +91,7 @@ func runVerify(cmd *cobra.Command, args []string) {
 	if verifyFresh {
 		pyArgs = append(pyArgs, "--fresh")
 	}
-	if verifyConcurrency != 4 {
-		pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", verifyConcurrency))
-	}
+	pyArgs = append(pyArgs, "--concurrency", fmt.Sprintf("%d", verifyConcurrency))
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -277,7 +277,11 @@ def run_analysis(
         return (result, time.monotonic() - start)
 
     def _on_complete(unit, analyze_output):
-        """Called under lock after successful analysis."""
+        """Called under lock after successful analysis.
+
+        All mutations to shared state (results, counts, code_by_route,
+        checkpoint) happen here under run_parallel's lock.
+        """
         result, unit_elapsed = analyze_output
         uid = unit.get("id", "unknown")
         result["unit_id"] = uid

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -19,6 +19,7 @@ from core import tracking
 from core.progress import ProgressReporter
 from core.utils import atomic_write_json
 from utilities.file_io import read_json
+from utilities.parallel_executor import run_parallel
 
 # Import existing analysis machinery
 from utilities.llm_client import AnthropicClient, get_global_tracker
@@ -63,6 +64,7 @@ def run_analysis(
     checkpoint_path: str | None = None,
     fresh: bool = False,
     skip_errors: bool = False,
+    concurrency: int = 4,
 ) -> AnalyzeResult:
     """Run Stage 1 vulnerability detection on a dataset.
 
@@ -224,65 +226,77 @@ def run_analysis(
     tracker = get_global_tracker()
     progress = ProgressReporter("Analyze", len(units), tracker=tracker, completed=len(completed_ids))
 
-    print(f"[Analyze] Analyzing {len(units)} units...", file=sys.stderr)
+    print(f"[Analyze] Analyzing {len(units)} units (concurrency={concurrency})...", file=sys.stderr)
 
+    # Filter to only units that need processing
+    pending_units = []
     for i, unit in enumerate(units):
         uid = unit.get("id", f"unit_{i}")
         if uid in completed_ids:
-            print(f"  [{i+1}/{len(units)}] {uid} -> (resumed)", file=sys.stderr)
+            print(f"  {uid} -> (resumed)", file=sys.stderr)
             continue
+        pending_units.append(unit)
 
-        print(f"  [{i+1}/{len(units)}] {uid}", file=sys.stderr, end="")
+    def _analyze_one(unit):
+        """Process a single unit (called from worker thread)."""
+        # Per-thread client to avoid last_call race on shared AnthropicClient
+        thread_client = AnthropicClient(model=model_id)
+        thread_corrector = JSONCorrector(thread_client)
+        return analyze_unit(
+            thread_client, unit,
+            use_multifile=True,
+            json_corrector=thread_corrector,
+            app_context=app_context,
+        )
 
-        try:
-            result = analyze_unit(
-                client, unit,
-                use_multifile=True,
-                json_corrector=json_corrector,
-                app_context=app_context,
-            )
+    def _on_complete(unit, result):
+        """Called under lock after successful analysis."""
+        uid = unit.get("id", "unknown")
+        result["unit_id"] = uid
+        if not result.get("finding") and result.get("verdict"):
+            result["finding"] = result["verdict"].lower()
 
-            # Ensure unit_id is always present
-            result["unit_id"] = uid
+        results.append(result)
 
-            # Ensure finding field is always set (may be None after JSON correction)
-            if not result.get("finding") and result.get("verdict"):
-                result["finding"] = result["verdict"].lower()
+        route_key = result.get("route_key", uid)
+        code_field = unit.get("code", {})
+        if isinstance(code_field, dict):
+            code_by_route[route_key] = code_field.get("primary_code", "")
+        else:
+            code_by_route[route_key] = code_field
 
-            results.append(result)
-
-            # Track code for verify step (code_by_route persisted in results.json)
-            route_key = result.get("route_key", uid)
-            code_field = unit.get("code", {})
-            if isinstance(code_field, dict):
-                code_by_route[route_key] = code_field.get("primary_code", "")
-            else:
-                code_by_route[route_key] = code_field
-
-            # Count verdicts
-            finding = result.get("finding", "error")
-            if finding in counts:
-                counts[finding] += 1
-            elif result.get("verdict") == "ERROR":
-                counts["errors"] += 1
-
-            print(f" -> {finding}", file=sys.stderr)
-
-        except Exception as e:
-            print(f" -> ERROR: {e}", file=sys.stderr)
+        finding = result.get("finding", "error")
+        if finding in counts:
+            counts[finding] += 1
+        elif result.get("verdict") == "ERROR":
             counts["errors"] += 1
-            results.append({
-                "unit_id": uid,
-                "verdict": "ERROR",
-                "finding": "error",
-                "error": str(e),
-            })
 
-        # Save checkpoint after each unit
         if checkpoint_path:
             _save_analyze_checkpoint(checkpoint_path, results, code_by_route, counts, dataset_path, model_id)
+        progress.report(unit_label=uid, detail=finding)
 
-        progress.report(unit_label=uid, detail=results[-1].get("finding", "error"))
+    def _on_error(unit, exc):
+        """Called under lock when analysis raises."""
+        uid = unit.get("id", "unknown")
+        print(f"  {uid} -> ERROR: {exc}", file=sys.stderr)
+        counts["errors"] += 1
+        results.append({
+            "unit_id": uid,
+            "verdict": "ERROR",
+            "finding": "error",
+            "error": str(exc),
+        })
+        if checkpoint_path:
+            _save_analyze_checkpoint(checkpoint_path, results, code_by_route, counts, dataset_path, model_id)
+        progress.report(unit_label=uid, detail="error")
+
+    run_parallel(
+        items=pending_units,
+        process_fn=_analyze_one,
+        concurrency=concurrency,
+        on_complete=_on_complete,
+        on_error=_on_error,
+    )
 
     progress.finish()
 
@@ -314,6 +328,9 @@ def run_analysis(
         print(f"[Analyze] Consistency check error (non-fatal): {e}", file=sys.stderr)
 
     # --- Write results ---
+    # Sort by unit_id for deterministic output regardless of concurrency
+    results.sort(key=lambda r: r.get("unit_id", ""))
+
     experiment_result = {
         "dataset": os.path.basename(dataset_path),
         "model": model_id,

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -260,7 +260,10 @@ def run_analysis(
     _thread_local = threading.local()
 
     def _analyze_one(unit):
-        """Process a single unit (called from worker thread)."""
+        """Process a single unit (called from worker thread).
+
+        Returns (result_dict, elapsed_seconds) tuple.
+        """
         start = time.monotonic()
         if not hasattr(_thread_local, "client"):
             _thread_local.client = AnthropicClient(model=model_id)
@@ -271,13 +274,12 @@ def run_analysis(
             json_corrector=_thread_local.corrector,
             app_context=app_context,
         )
-        result["_elapsed"] = time.monotonic() - start
-        return result
+        return (result, time.monotonic() - start)
 
-    def _on_complete(unit, result):
+    def _on_complete(unit, analyze_output):
         """Called under lock after successful analysis."""
+        result, unit_elapsed = analyze_output
         uid = unit.get("id", "unknown")
-        unit_elapsed = result.pop("_elapsed", 0.0)
         result["unit_id"] = uid
         if not result.get("finding") and result.get("verdict"):
             result["finding"] = result["verdict"].lower()

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -11,6 +11,8 @@ import json
 import os
 import shutil
 import sys
+import threading
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -190,7 +192,6 @@ def run_analysis(
         "vulnerable": 0,
         "bypassable": 0,
         "inconclusive": 0,
-        "insufficient_context": 0,
         "protected": 0,
         "safe": 0,
         "errors": 0,
@@ -240,13 +241,11 @@ def run_analysis(
 
     # Per-thread client/corrector to avoid last_call race on shared AnthropicClient.
     # Using threading.local() so each thread creates once and reuses.
-    import threading as _threading
-    import time as _time
-    _thread_local = _threading.local()
+    _thread_local = threading.local()
 
     def _analyze_one(unit):
         """Process a single unit (called from worker thread)."""
-        start = _time.monotonic()
+        start = time.monotonic()
         if not hasattr(_thread_local, "client"):
             _thread_local.client = AnthropicClient(model=model_id)
             _thread_local.corrector = JSONCorrector(_thread_local.client)
@@ -256,12 +255,13 @@ def run_analysis(
             json_corrector=_thread_local.corrector,
             app_context=app_context,
         )
-        result["_elapsed"] = _time.monotonic() - start
+        result["_elapsed"] = time.monotonic() - start
         return result
 
     def _on_complete(unit, result):
         """Called under lock after successful analysis."""
         uid = unit.get("id", "unknown")
+        unit_elapsed = result.pop("_elapsed", 0.0)
         result["unit_id"] = uid
         if not result.get("finding") and result.get("verdict"):
             result["finding"] = result["verdict"].lower()
@@ -283,7 +283,7 @@ def run_analysis(
 
         if checkpoint_path:
             _save_analyze_checkpoint(checkpoint_path, results, code_by_route, counts, dataset_path, model_id)
-        progress.report(unit_label=uid, detail=finding, unit_elapsed=result.get("_elapsed", 0.0))
+        progress.report(unit_label=uid, detail=finding, unit_elapsed=unit_elapsed)
 
     def _on_error(unit, exc):
         """Called under lock when analysis raises."""
@@ -368,7 +368,6 @@ def run_analysis(
         vulnerable=counts["vulnerable"],
         bypassable=counts["bypassable"],
         inconclusive=counts["inconclusive"],
-        insufficient_context=counts["insufficient_context"],
         protected=counts["protected"],
         safe=counts["safe"],
         errors=counts["errors"],

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -190,6 +190,7 @@ def run_analysis(
         "vulnerable": 0,
         "bypassable": 0,
         "inconclusive": 0,
+        "insufficient_context": 0,
         "protected": 0,
         "safe": 0,
         "errors": 0,
@@ -237,17 +238,26 @@ def run_analysis(
             continue
         pending_units.append(unit)
 
+    # Per-thread client/corrector to avoid last_call race on shared AnthropicClient.
+    # Using threading.local() so each thread creates once and reuses.
+    import threading as _threading
+    import time as _time
+    _thread_local = _threading.local()
+
     def _analyze_one(unit):
         """Process a single unit (called from worker thread)."""
-        # Per-thread client to avoid last_call race on shared AnthropicClient
-        thread_client = AnthropicClient(model=model_id)
-        thread_corrector = JSONCorrector(thread_client)
-        return analyze_unit(
-            thread_client, unit,
+        start = _time.monotonic()
+        if not hasattr(_thread_local, "client"):
+            _thread_local.client = AnthropicClient(model=model_id)
+            _thread_local.corrector = JSONCorrector(_thread_local.client)
+        result = analyze_unit(
+            _thread_local.client, unit,
             use_multifile=True,
-            json_corrector=thread_corrector,
+            json_corrector=_thread_local.corrector,
             app_context=app_context,
         )
+        result["_elapsed"] = _time.monotonic() - start
+        return result
 
     def _on_complete(unit, result):
         """Called under lock after successful analysis."""
@@ -273,7 +283,7 @@ def run_analysis(
 
         if checkpoint_path:
             _save_analyze_checkpoint(checkpoint_path, results, code_by_route, counts, dataset_path, model_id)
-        progress.report(unit_label=uid, detail=finding)
+        progress.report(unit_label=uid, detail=finding, unit_elapsed=result.get("_elapsed", 0.0))
 
     def _on_error(unit, exc):
         """Called under lock when analysis raises."""
@@ -358,6 +368,7 @@ def run_analysis(
         vulnerable=counts["vulnerable"],
         bypassable=counts["bypassable"],
         inconclusive=counts["inconclusive"],
+        insufficient_context=counts["insufficient_context"],
         protected=counts["protected"],
         safe=counts["safe"],
         errors=counts["errors"],

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -26,6 +26,7 @@ def enhance_dataset(
     fresh: bool = False,
     skip_errors: bool = False,
     model: str = "sonnet",
+    concurrency: int = 4,
 ) -> EnhanceResult:
     """Enhance a parsed dataset with security context.
 
@@ -154,6 +155,7 @@ def enhance_dataset(
             checkpoint_path=checkpoint_path,
             progress_callback=_on_unit_done,
             skip_errors=skip_errors,
+            concurrency=concurrency,
         )
     elif mode == "single-shot":
         enhanced = enhancer.enhance_dataset(

--- a/libs/openant-core/core/progress.py
+++ b/libs/openant-core/core/progress.py
@@ -6,6 +6,7 @@ which the Go CLI streams to the terminal in real-time.
 """
 
 import sys
+import threading
 import time
 from typing import Optional
 
@@ -59,6 +60,7 @@ class ProgressReporter:
         self.tracker = tracker
         self.start_time = time.monotonic()
         self.completed = completed
+        self._lock = threading.Lock()
 
         # Width for the counter so alignment stays consistent
         self._width = len(str(total))
@@ -101,38 +103,39 @@ class ProgressReporter:
             detail: Extra info (e.g. classification, verdict).
             unit_elapsed: How long this specific unit took, in seconds.
         """
-        self.completed += 1
-        elapsed = time.monotonic() - self.start_time
-        eta = self._estimate_remaining(elapsed)
-        cost = self._get_cost()
+        with self._lock:
+            self.completed += 1
+            elapsed = time.monotonic() - self.start_time
+            eta = self._estimate_remaining(elapsed)
+            cost = self._get_cost()
 
-        # Truncate label if too long
-        if len(unit_label) > 50:
-            unit_label = unit_label[:47] + "..."
+            # Truncate label if too long
+            if len(unit_label) > 50:
+                unit_label = unit_label[:47] + "..."
 
-        # Build the progress line
-        parts = [
-            f"[{self.step_name}]",
-            f"{self.completed:>{self._width}}/{self.total} done",
-            unit_label,
-            f"-> {detail}" if detail else "",
-        ]
-        parts = [p for p in parts if p]
-        if unit_elapsed > 0:
-            parts.append(f"({unit_elapsed:.1f}s)")
+            # Build the progress line
+            parts = [
+                f"[{self.step_name}]",
+                f"{self.completed:>{self._width}}/{self.total} done",
+                unit_label,
+                f"-> {detail}" if detail else "",
+            ]
+            parts = [p for p in parts if p]
+            if unit_elapsed > 0:
+                parts.append(f"({unit_elapsed:.1f}s)")
 
-        meta = f"(elapsed {_fmt_duration(elapsed)}, ETA {eta}, {_fmt_cost(cost)})"
-        parts.append(meta)
+            meta = f"(elapsed {_fmt_duration(elapsed)}, ETA {eta}, {_fmt_cost(cost)})"
+            parts.append(meta)
 
-        line = "  ".join(parts)
-        print(line, file=sys.stderr, flush=True)
+            line = "  ".join(parts)
+            print(line, file=sys.stderr, flush=True)
 
-        # Periodic summary
-        if (
-            self.completed % self._summary_interval == 0
-            and self.completed < self.total
-        ):
-            self._print_summary(elapsed, cost)
+            # Periodic summary
+            if (
+                self.completed % self._summary_interval == 0
+                and self.completed < self.total
+            ):
+                self._print_summary(elapsed, cost)
 
     def _print_summary(self, elapsed: float, cost: float) -> None:
         """Print a highlighted summary line."""

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -156,6 +156,7 @@ def scan_repository(
     enhance_mode: str = "agentic",
     dynamic_test: bool = False,
     fresh: bool = False,
+    concurrency: int = 4,
 ) -> ScanResult:
     """Scan a repository for vulnerabilities.
 
@@ -380,6 +381,7 @@ def scan_repository(
                     mode=enhance_mode,
                     checkpoint_path=checkpoint_path,
                     fresh=fresh,
+                    concurrency=concurrency,
                 )
 
                 ctx.summary = {
@@ -438,6 +440,7 @@ def scan_repository(
                 repo_path=repo_path,
                 limit=limit,
                 model=model,
+                concurrency=concurrency,
             )
 
             ctx.summary = {
@@ -518,6 +521,7 @@ def scan_repository(
                     analyzer_output_path=parse_result.analyzer_output_path,
                     app_context_path=app_context_path,
                     repo_path=repo_path,
+                    concurrency=concurrency,
                 )
 
                 ctx.summary = {

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -37,6 +37,7 @@ def run_verification(
     repo_path: str | None = None,
     checkpoint_path: str | None = None,
     fresh: bool = False,
+    concurrency: int = 4,
 ) -> VerifyResult:
     """Run Stage 2 attacker-simulation verification on Stage 1 results.
 
@@ -199,6 +200,7 @@ def run_verification(
             vulnerable_results, code_by_route,
             progress_callback=_on_finding_done,
             checkpoint_path=checkpoint_path,
+            concurrency=concurrency,
         )
     except Exception as e:
         print(f"[Verify] ERROR during batch verification: {e}", file=sys.stderr)

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -31,6 +31,22 @@ def _output_json(data: dict):
     sys.stdout.write("\n")
 
 
+def _validate_concurrency(value: int) -> int:
+    """Validate and return concurrency value, warn if using local mode."""
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"--concurrency must be >= 1, got {value}")
+    if value > 1:
+        from utilities.local_claude import is_enabled as _use_local_claude
+        if _use_local_claude():
+            print(
+                f"[Warning] concurrency={value} with OPENANT_LOCAL_CLAUDE=true "
+                f"will spawn {value} simultaneous claude CLI processes. "
+                f"Use --concurrency 1 if this causes issues.",
+                file=sys.stderr,
+            )
+    return value
+
+
 def cmd_scan(args):
     """Scan a repository end-to-end."""
     from core.scanner import scan_repository
@@ -39,6 +55,7 @@ def cmd_scan(args):
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_")
 
     try:
+        concurrency = _validate_concurrency(args.concurrency)
         result = scan_repository(
             repo_path=args.repo,
             output_dir=output_dir,
@@ -54,6 +71,7 @@ def cmd_scan(args):
             enhance_mode=args.enhance_mode,
             dynamic_test=args.dynamic_test,
             fresh=args.fresh,
+            concurrency=concurrency,
         )
 
         _output_json(success(result.to_dict()))
@@ -132,6 +150,7 @@ def cmd_enhance(args):
             "repo_path": os.path.abspath(args.repo_path) if args.repo_path else None,
             "mode": args.mode,
         }) as ctx:
+            concurrency = _validate_concurrency(args.concurrency)
             result = enhance_dataset(
                 dataset_path=args.dataset,
                 output_path=output_path,
@@ -140,6 +159,7 @@ def cmd_enhance(args):
                 mode=args.mode,
                 fresh=args.fresh,
                 skip_errors=args.skip_errors,
+                concurrency=concurrency,
             )
 
             ctx.summary = {
@@ -179,6 +199,7 @@ def cmd_analyze(args):
             "exploitable_only": args.exploitable_only,
             "limit": args.limit,
         }) as ctx:
+            concurrency = _validate_concurrency(args.concurrency)
             result = run_analysis(
                 dataset_path=args.dataset,
                 output_dir=output_dir,
@@ -190,6 +211,7 @@ def cmd_analyze(args):
                 exploitable_only=args.exploitable_only,
                 fresh=args.fresh,
                 skip_errors=args.skip_errors,
+                concurrency=concurrency,
             )
 
             ctx.summary = {
@@ -225,6 +247,7 @@ def cmd_analyze(args):
                         analyzer_output_path=args.analyzer_output,
                         app_context_path=args.app_context,
                         repo_path=args.repo_path,
+                        concurrency=concurrency,
                     )
 
                     vctx.summary = {
@@ -270,6 +293,7 @@ def cmd_verify(args):
             "app_context_path": os.path.abspath(args.app_context) if args.app_context else None,
             "repo_path": os.path.abspath(args.repo_path) if args.repo_path else None,
         }) as ctx:
+            concurrency = _validate_concurrency(args.concurrency)
             result = run_verification(
                 results_path=args.results,
                 output_dir=output_dir,
@@ -277,6 +301,7 @@ def cmd_verify(args):
                 app_context_path=args.app_context,
                 repo_path=args.repo_path,
                 fresh=args.fresh,
+                concurrency=concurrency,
             )
 
             ctx.summary = {
@@ -507,6 +532,8 @@ def main():
     scan_p.add_argument("--model", choices=["opus", "sonnet"], default="opus", help="Model (default: opus)")
     scan_p.add_argument("--fresh", action="store_true",
                         help="Ignore previous progress and rerun all steps from scratch")
+    scan_p.add_argument("--concurrency", "-j", type=int, default=4,
+                        help="Number of concurrent LLM calls (default: 4)")
     scan_p.set_defaults(func=cmd_scan)
 
     # ---------------------------------------------------------------
@@ -549,6 +576,8 @@ def main():
         default="agentic",
         help="Enhancement mode (default: agentic — thorough but more expensive)",
     )
+    enhance_p.add_argument("--concurrency", "-j", type=int, default=4,
+                           help="Number of concurrent LLM calls (default: 4)")
     enhance_p.set_defaults(func=cmd_enhance)
 
     # ---------------------------------------------------------------
@@ -569,6 +598,8 @@ def main():
                            help="Ignore checkpoint and reanalyze all units from scratch")
     analyze_p.add_argument("--skip-errors", action="store_true",
                            help="Skip errored units instead of retrying them")
+    analyze_p.add_argument("--concurrency", "-j", type=int, default=4,
+                           help="Number of concurrent LLM calls (default: 4)")
     analyze_p.set_defaults(func=cmd_analyze)
 
     # ---------------------------------------------------------------
@@ -582,6 +613,8 @@ def main():
     verify_p.add_argument("--output", "-o", help="Output directory (default: temp dir)")
     verify_p.add_argument("--fresh", action="store_true",
                           help="Ignore checkpoint and reverify all findings from scratch")
+    verify_p.add_argument("--concurrency", "-j", type=int, default=4,
+                          help="Number of concurrent LLM calls (default: 4)")
     verify_p.set_defaults(func=cmd_verify)
 
     # ---------------------------------------------------------------

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -144,13 +144,13 @@ def cmd_enhance(args):
     output_dir = os.path.dirname(os.path.abspath(output_path))
 
     try:
+        concurrency = _validate_concurrency(args.concurrency)
         with step_context("enhance", output_dir, inputs={
             "dataset_path": os.path.abspath(args.dataset),
             "analyzer_output_path": os.path.abspath(args.analyzer_output) if args.analyzer_output else None,
             "repo_path": os.path.abspath(args.repo_path) if args.repo_path else None,
             "mode": args.mode,
         }) as ctx:
-            concurrency = _validate_concurrency(args.concurrency)
             result = enhance_dataset(
                 dataset_path=args.dataset,
                 output_path=output_path,
@@ -191,6 +191,7 @@ def cmd_analyze(args):
     from core.step_report import step_context
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_analyze_")
+    concurrency = _validate_concurrency(args.concurrency)
 
     try:
         with step_context("analyze", output_dir, inputs={
@@ -199,7 +200,6 @@ def cmd_analyze(args):
             "exploitable_only": args.exploitable_only,
             "limit": args.limit,
         }) as ctx:
-            concurrency = _validate_concurrency(args.concurrency)
             result = run_analysis(
                 dataset_path=args.dataset,
                 output_dir=output_dir,
@@ -285,6 +285,7 @@ def cmd_verify(args):
     from core.step_report import step_context
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_verify_")
+    concurrency = _validate_concurrency(args.concurrency)
 
     try:
         with step_context("verify", output_dir, inputs={
@@ -293,7 +294,6 @@ def cmd_verify(args):
             "app_context_path": os.path.abspath(args.app_context) if args.app_context else None,
             "repo_path": os.path.abspath(args.repo_path) if args.repo_path else None,
         }) as ctx:
-            concurrency = _validate_concurrency(args.concurrency)
             result = run_verification(
                 results_path=args.results,
                 output_dir=output_dir,

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -32,9 +32,13 @@ def _output_json(data: dict):
 
 
 def _validate_concurrency(value: int) -> int:
-    """Validate and return concurrency value, warn if using local mode."""
+    """Validate and return concurrency value, warn if using local mode.
+
+    Raises ValueError (not ArgumentTypeError) so the caller's except
+    Exception handler produces a clean JSON error via _output_json().
+    """
     if value < 1:
-        raise argparse.ArgumentTypeError(f"--concurrency must be >= 1, got {value}")
+        raise ValueError(f"--concurrency must be >= 1, got {value}")
     if value > 1:
         from utilities.local_claude import is_enabled as _use_local_claude
         if _use_local_claude():

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -191,9 +191,9 @@ def cmd_analyze(args):
     from core.step_report import step_context
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_analyze_")
-    concurrency = _validate_concurrency(args.concurrency)
 
     try:
+        concurrency = _validate_concurrency(args.concurrency)
         with step_context("analyze", output_dir, inputs={
             "dataset_path": os.path.abspath(args.dataset),
             "model": args.model,
@@ -285,9 +285,9 @@ def cmd_verify(args):
     from core.step_report import step_context
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_verify_")
-    concurrency = _validate_concurrency(args.concurrency)
 
     try:
+        concurrency = _validate_concurrency(args.concurrency)
         with step_context("verify", output_dir, inputs={
             "results_path": os.path.abspath(args.results),
             "analyzer_output_path": os.path.abspath(args.analyzer_output),

--- a/libs/openant-core/tests/test_parallel_executor.py
+++ b/libs/openant-core/tests/test_parallel_executor.py
@@ -1,0 +1,155 @@
+"""Tests for utilities.parallel_executor."""
+
+import threading
+import pytest
+
+from utilities.parallel_executor import run_parallel
+
+
+class TestRunParallelValidation:
+    """Input validation tests."""
+
+    def test_concurrency_zero_raises(self):
+        with pytest.raises(ValueError, match="concurrency must be >= 1"):
+            run_parallel(items=[1], process_fn=lambda x: x, concurrency=0)
+
+    def test_concurrency_negative_raises(self):
+        with pytest.raises(ValueError, match="concurrency must be >= 1"):
+            run_parallel(items=[1], process_fn=lambda x: x, concurrency=-1)
+
+    def test_empty_items_returns_empty(self):
+        results = run_parallel(items=[], process_fn=lambda x: x, concurrency=4)
+        assert results == []
+
+
+class TestSerialPath:
+    """Tests for concurrency=1 (serial fast-path)."""
+
+    def test_serial_processes_all_items(self):
+        results = run_parallel(
+            items=[1, 2, 3],
+            process_fn=lambda x: x * 10,
+            concurrency=1,
+        )
+        assert sorted(r for _, r in results) == [10, 20, 30]
+
+    def test_serial_calls_on_complete(self):
+        completed = []
+        run_parallel(
+            items=["a", "b"],
+            process_fn=lambda x: x.upper(),
+            concurrency=1,
+            on_complete=lambda item, result: completed.append((item, result)),
+        )
+        assert sorted(completed) == [("a", "A"), ("b", "B")]
+
+    def test_serial_calls_on_error(self):
+        errors = []
+
+        def _fail(x):
+            raise RuntimeError(f"fail-{x}")
+
+        run_parallel(
+            items=[1, 2],
+            process_fn=_fail,
+            concurrency=1,
+            on_error=lambda item, exc: errors.append((item, str(exc))),
+        )
+        assert sorted(errors) == [(1, "fail-1"), (2, "fail-2")]
+
+    def test_serial_error_does_not_stop_processing(self):
+        """Errors on individual items don't prevent other items from processing."""
+        def _sometimes_fail(x):
+            if x == 2:
+                raise RuntimeError("boom")
+            return x * 10
+
+        results = run_parallel(
+            items=[1, 2, 3],
+            process_fn=_sometimes_fail,
+            concurrency=1,
+        )
+        assert sorted(r for _, r in results) == [10, 30]
+
+
+class TestParallelPath:
+    """Tests for concurrency > 1 (threaded path)."""
+
+    def test_parallel_processes_all_items(self):
+        results = run_parallel(
+            items=[1, 2, 3, 4, 5],
+            process_fn=lambda x: x * 10,
+            concurrency=3,
+        )
+        assert sorted(r for _, r in results) == [10, 20, 30, 40, 50]
+
+    def test_parallel_calls_on_complete_under_lock(self):
+        """on_complete calls are serialized — no interleaving."""
+        completed = []
+        lock_holders = []
+
+        def _on_complete(item, result):
+            # If another thread is in on_complete simultaneously, this would fail
+            lock_holders.append(threading.current_thread().ident)
+            completed.append(result)
+            lock_holders.pop()
+
+        run_parallel(
+            items=list(range(20)),
+            process_fn=lambda x: x,
+            concurrency=4,
+            on_complete=_on_complete,
+        )
+        assert len(completed) == 20
+
+    def test_parallel_calls_on_error(self):
+        errors = []
+
+        def _fail(x):
+            raise ValueError(f"err-{x}")
+
+        run_parallel(
+            items=[1, 2, 3],
+            process_fn=_fail,
+            concurrency=2,
+            on_error=lambda item, exc: errors.append(item),
+        )
+        assert sorted(errors) == [1, 2, 3]
+
+    def test_parallel_mixed_success_and_error(self):
+        """Some items succeed, some fail — both callbacks are invoked."""
+        completed = []
+        errored = []
+
+        def _fn(x):
+            if x % 2 == 0:
+                raise RuntimeError("even")
+            return x
+
+        run_parallel(
+            items=[1, 2, 3, 4, 5],
+            process_fn=_fn,
+            concurrency=3,
+            on_complete=lambda item, result: completed.append(item),
+            on_error=lambda item, exc: errored.append(item),
+        )
+        assert sorted(completed) == [1, 3, 5]
+        assert sorted(errored) == [2, 4]
+
+    def test_parallel_results_inside_lock(self):
+        """Results list is built under the lock (no race on append)."""
+        results = run_parallel(
+            items=list(range(50)),
+            process_fn=lambda x: x,
+            concurrency=8,
+        )
+        assert len(results) == 50
+
+    def test_parallel_no_callbacks(self):
+        """Works fine with no on_complete or on_error."""
+        results = run_parallel(
+            items=[1, 2, 3],
+            process_fn=lambda x: x * 2,
+            concurrency=2,
+        )
+        assert sorted(r for _, r in results) == [2, 4, 6]

--- a/libs/openant-core/tests/test_resume_stage1.py
+++ b/libs/openant-core/tests/test_resume_stage1.py
@@ -125,12 +125,15 @@ def _make_dataset(tmp_path, num_units=3):
 
 
 def _mock_enhance_unit(unit, index, tracker, verbose):
-    """Mock for enhance_unit_with_agent that adds a basic agent_context."""
-    unit["agent_context"] = {
-        "security_classification": "neutral",
-        "confidence": 0.8,
-        "include_functions": [],
-        "agent_metadata": {"iterations": 1},
+    """Mock for enhance_unit_with_agent that returns a patch dict."""
+    return {
+        "agent_context": {
+            "security_classification": "neutral",
+            "confidence": 0.8,
+            "include_functions": [],
+            "agent_metadata": {"iterations": 1},
+        },
+        "code_patches": None,
     }
 
 
@@ -142,11 +145,14 @@ def _mock_enhance_unit_fail_after(n):
         call_count["count"] += 1
         if call_count["count"] > n:
             raise RuntimeError("Simulated LLM failure")
-        unit["agent_context"] = {
-            "security_classification": "neutral",
-            "confidence": 0.8,
-            "include_functions": [],
-            "agent_metadata": {"iterations": 1},
+        return {
+            "agent_context": {
+                "security_classification": "neutral",
+                "confidence": 0.8,
+                "include_functions": [],
+                "agent_metadata": {"iterations": 1},
+            },
+            "code_patches": None,
         }
 
     return _mock

--- a/libs/openant-core/tests/test_resume_stage2.py
+++ b/libs/openant-core/tests/test_resume_stage2.py
@@ -170,7 +170,7 @@ def _verify_patches():
     mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
     mock_verifier_instance = MagicMock()
     mock_verifier_instance.verify_batch.side_effect = (
-        lambda results, cbr, progress_callback=None, checkpoint_path=None:
+        lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
         _mock_verify_batch(results, mock_result)
     )
 
@@ -435,7 +435,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None:
+            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -462,7 +462,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None:
+            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -506,7 +506,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None:
+            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -544,7 +544,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None:
+            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
             _mock_verify_batch(results, mock_result)
         )
 

--- a/libs/openant-core/tests/test_resume_stage2.py
+++ b/libs/openant-core/tests/test_resume_stage2.py
@@ -170,7 +170,7 @@ def _verify_patches():
     mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
     mock_verifier_instance = MagicMock()
     mock_verifier_instance.verify_batch.side_effect = (
-        lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
+        lambda results, cbr, **kwargs:
         _mock_verify_batch(results, mock_result)
     )
 
@@ -240,6 +240,7 @@ class TestAnalyzeCheckpoint:
                     dataset_path=dataset_path,
                     output_dir=output_dir,
                     checkpoint_path=checkpoint_path,
+                    concurrency=1,  # serial to guarantee exact crash point
                 )
 
         # Checkpoint should exist with the 2 completed units
@@ -257,6 +258,7 @@ class TestAnalyzeCheckpoint:
                 dataset_path=dataset_path,
                 output_dir=output_dir,
                 checkpoint_path=checkpoint_path,
+                concurrency=1,  # serial to match first run's checkpoint
             )
 
         # Only 3 remaining units should have been analyzed
@@ -435,7 +437,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
+            lambda results, cbr, **kwargs:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -462,7 +464,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
+            lambda results, cbr, **kwargs:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -506,7 +508,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
+            lambda results, cbr, **kwargs:
             _mock_verify_batch(results, mock_result)
         )
 
@@ -544,7 +546,7 @@ class TestVerifyCheckpoint:
         mock_result = MockVerificationResult(agree=True, correct_finding="vulnerable")
         mock_verifier = MagicMock()
         mock_verifier.verify_batch.side_effect = (
-            lambda results, cbr, progress_callback=None, checkpoint_path=None, concurrency=4:
+            lambda results, cbr, **kwargs:
             _mock_verify_batch(results, mock_result)
         )
 

--- a/libs/openant-core/utilities/agentic_enhancer/__init__.py
+++ b/libs/openant-core/utilities/agentic_enhancer/__init__.py
@@ -16,6 +16,7 @@ from .agent import (
     ContextAgent,
     AgentResult,
     enhance_unit_with_agent,
+    apply_enhance_patch,
     create_reachability_context
 )
 from .repository_index import RepositoryIndex, load_index_from_file
@@ -27,6 +28,7 @@ __all__ = [
     "ContextAgent",
     "AgentResult",
     "enhance_unit_with_agent",
+    "apply_enhance_patch",
     "create_reachability_context",
     "RepositoryIndex",
     "load_index_from_file",

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -362,8 +362,9 @@ def enhance_unit_with_agent(
         static_callers=static_callers
     )
 
-    # Add result to unit
-    unit["agent_context"] = result.to_dict()
+    # Build a patch dict instead of mutating unit directly.
+    # The caller applies these under a lock for thread safety.
+    patch = {"agent_context": result.to_dict(), "code_patches": None}
 
     # Assemble additional code if functions were identified
     if result.include_functions:
@@ -385,22 +386,37 @@ def enhance_unit_with_agent(
                 if colon_idx > 0:
                     additional_files.add(func_id[:colon_idx])
 
-        # Append to primary_code with file boundaries
+        # Build code assembly patch (instead of mutating unit["code"] directly)
         if additional_code and isinstance(unit.get("code"), dict):
             FILE_BOUNDARY = "\n\n// ========== File Boundary ==========\n\n"
             current_code = unit["code"].get("primary_code", "")
             assembled = current_code + FILE_BOUNDARY + FILE_BOUNDARY.join(additional_code)
-            unit["code"]["primary_code"] = assembled
 
-            # Update metadata
-            origin = unit["code"].get("primary_origin", {})
+            origin = dict(unit["code"].get("primary_origin", {}))
             current_files = set(origin.get("files_included", []))
             origin["files_included"] = list(current_files | additional_files)
             origin["enhanced"] = True
             origin["enhanced_length"] = len(assembled)
-            unit["code"]["primary_origin"] = origin
 
-    return unit
+            patch["code_patches"] = {
+                "primary_code": assembled,
+                "primary_origin": origin,
+            }
+
+    return patch
+
+
+def apply_enhance_patch(unit: dict, patch: dict) -> None:
+    """Apply an enhance patch to a unit dict (must be called under lock).
+
+    Args:
+        unit: The unit dict to mutate.
+        patch: Dict returned by ``enhance_unit_with_agent()``.
+    """
+    unit["agent_context"] = patch["agent_context"]
+    if patch["code_patches"] and isinstance(unit.get("code"), dict):
+        unit["code"]["primary_code"] = patch["code_patches"]["primary_code"]
+        unit["code"]["primary_origin"] = patch["code_patches"]["primary_origin"]
 
 
 def create_reachability_context(

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -24,6 +24,8 @@ from typing import Callable, Optional
 from .file_io import read_json, write_json
 from .llm_client import AnthropicClient, TokenTracker, get_global_tracker
 from .agentic_enhancer import enhance_unit_with_agent, load_index_from_file
+from .agentic_enhancer.agent import apply_enhance_patch
+from .parallel_executor import run_parallel
 
 
 # Null logger that discards all messages (used when no logger provided)
@@ -344,6 +346,7 @@ class ContextEnhancer:
         checkpoint_path: str = None,
         progress_callback: Optional[Callable] = None,
         skip_errors: bool = False,
+        concurrency: int = 4,
     ) -> dict:
         """
         Enhance all units using agentic approach with tool use.
@@ -439,55 +442,65 @@ class ContextEnhancer:
                     agentic_stats["neutral_found"] += 1
                 agentic_stats["total_iterations"] += agent_ctx.get("agent_metadata", {}).get("iterations", 0)
 
-        processed_this_run = 0
-        for i, unit in enumerate(units):
-            unit_id = unit.get("id")
+        # Filter to pending units
+        pending_units = [u for u in units if u.get("id") not in processed_ids]
 
-            # Skip already-processed units
-            if unit_id in processed_ids:
-                continue
+        self._log("info", f"Processing {len(pending_units)} units (concurrency={concurrency})")
 
-            processed_this_run += 1
-            if processed_this_run % batch_size == 1 or processed_this_run == 1:
-                self._log("info", f"Processing unit {agentic_stats['units_processed'] + 1}/{total}", unit_id=unit_id)
+        def _enhance_one(unit):
+            """Process a single unit (called from worker thread)."""
+            return enhance_unit_with_agent(unit, index, self.tracker, verbose)
 
-            unit_start = time.monotonic()
-            try:
-                enhance_unit_with_agent(unit, index, self.tracker, verbose)
-                agentic_stats["units_processed"] += 1
+        def _on_complete(unit, patch):
+            """Called under lock after successful enhancement."""
+            unit_id = unit.get("id", "?")
 
-                agent_ctx = unit.get("agent_context", {})
-                if agent_ctx.get("include_functions"):
-                    agentic_stats["units_with_context"] += 1
-                    agentic_stats["functions_added"] += len(agent_ctx["include_functions"])
+            # Apply patch to unit under lock (thread-safe)
+            apply_enhance_patch(unit, patch)
+            agentic_stats["units_processed"] += 1
 
-                classification = agent_ctx.get("security_classification", "neutral")
-                if classification == "security_control":
-                    agentic_stats["security_controls_found"] += 1
-                elif classification == "vulnerable":
-                    agentic_stats["vulnerable_found"] += 1
-                else:
-                    agentic_stats["neutral_found"] += 1
+            agent_ctx = patch["agent_context"]
+            if agent_ctx.get("include_functions"):
+                agentic_stats["units_with_context"] += 1
+                agentic_stats["functions_added"] += len(agent_ctx["include_functions"])
 
-                agentic_stats["total_iterations"] += agent_ctx.get("agent_metadata", {}).get("iterations", 0)
+            classification = agent_ctx.get("security_classification", "neutral")
+            if classification == "security_control":
+                agentic_stats["security_controls_found"] += 1
+            elif classification == "vulnerable":
+                agentic_stats["vulnerable_found"] += 1
+            else:
+                agentic_stats["neutral_found"] += 1
 
-            except Exception as e:
-                classification = "error"
-                agentic_stats["errors"] += 1
-                self._log("error", "Error processing unit", unit_id=unit_id, error=str(e))
-                unit["agent_context"] = {
-                    "error": str(e),
-                    "security_classification": "neutral",
-                    "confidence": 0.0
-                }
+            agentic_stats["total_iterations"] += agent_ctx.get("agent_metadata", {}).get("iterations", 0)
 
-            unit_elapsed = time.monotonic() - unit_start
-            if progress_callback:
-                progress_callback(unit_id or "?", classification, unit_elapsed)
-
-            # Save checkpoint after each unit
             if checkpoint_path:
                 self._save_checkpoint(dataset, checkpoint_path, agentic_stats)
+            if progress_callback:
+                progress_callback(unit_id, classification, 0.0)
+
+        def _on_error(unit, exc):
+            """Called under lock when enhancement raises."""
+            unit_id = unit.get("id", "?")
+            agentic_stats["errors"] += 1
+            self._log("error", "Error processing unit", unit_id=unit_id, error=str(exc))
+            unit["agent_context"] = {
+                "error": str(exc),
+                "security_classification": "neutral",
+                "confidence": 0.0
+            }
+            if checkpoint_path:
+                self._save_checkpoint(dataset, checkpoint_path, agentic_stats)
+            if progress_callback:
+                progress_callback(unit_id, "error", 0.0)
+
+        run_parallel(
+            items=pending_units,
+            process_fn=_enhance_one,
+            concurrency=concurrency,
+            on_complete=_on_complete,
+            on_error=_on_error,
+        )
 
         # Clean up checkpoint on success
         if checkpoint_path and os.path.exists(checkpoint_path):

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -449,7 +449,10 @@ class ContextEnhancer:
 
         def _enhance_one(unit):
             """Process a single unit (called from worker thread)."""
-            return enhance_unit_with_agent(unit, index, self.tracker, verbose)
+            start = time.monotonic()
+            patch = enhance_unit_with_agent(unit, index, self.tracker, verbose)
+            patch["_elapsed"] = time.monotonic() - start
+            return patch
 
         def _on_complete(unit, patch):
             """Called under lock after successful enhancement."""
@@ -477,7 +480,7 @@ class ContextEnhancer:
             if checkpoint_path:
                 self._save_checkpoint(dataset, checkpoint_path, agentic_stats)
             if progress_callback:
-                progress_callback(unit_id, classification, 0.0)
+                progress_callback(unit_id, classification, patch.get("_elapsed", 0.0))
 
         def _on_error(unit, exc):
             """Called under lock when enhancement raises."""

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -448,14 +448,17 @@ class ContextEnhancer:
         self._log("info", f"Processing {len(pending_units)} units (concurrency={concurrency})")
 
         def _enhance_one(unit):
-            """Process a single unit (called from worker thread)."""
+            """Process a single unit (called from worker thread).
+
+            Returns (patch_dict, elapsed_seconds) tuple.
+            """
             start = time.monotonic()
             patch = enhance_unit_with_agent(unit, index, self.tracker, verbose)
-            patch["_elapsed"] = time.monotonic() - start
-            return patch
+            return (patch, time.monotonic() - start)
 
-        def _on_complete(unit, patch):
+        def _on_complete(unit, enhance_output):
             """Called under lock after successful enhancement."""
+            patch, unit_elapsed = enhance_output
             unit_id = unit.get("id", "?")
 
             # Apply patch to unit under lock (thread-safe)
@@ -480,7 +483,7 @@ class ContextEnhancer:
             if checkpoint_path:
                 self._save_checkpoint(dataset, checkpoint_path, agentic_stats)
             if progress_callback:
-                progress_callback(unit_id, classification, patch.get("_elapsed", 0.0))
+                progress_callback(unit_id, classification, unit_elapsed)
 
         def _on_error(unit, exc):
             """Called under lock when enhancement raises."""

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -457,7 +457,12 @@ class ContextEnhancer:
             return (patch, time.monotonic() - start)
 
         def _on_complete(unit, enhance_output):
-            """Called under lock after successful enhancement."""
+            """Called under lock after successful enhancement.
+
+            Note: all mutations to shared state (unit dict, agentic_stats,
+            checkpoint) happen here under run_parallel's lock — not in
+            the worker thread. This is what makes the parallel path safe.
+            """
             patch, unit_elapsed = enhance_output
             unit_id = unit.get("id", "?")
 
@@ -486,7 +491,12 @@ class ContextEnhancer:
                 progress_callback(unit_id, classification, unit_elapsed)
 
         def _on_error(unit, exc):
-            """Called under lock when enhancement raises."""
+            """Called under lock when enhancement raises.
+
+            Mutates unit directly (no patch) since the error case is simple
+            and doesn't involve code assembly. This is safe because
+            run_parallel holds the lock during this callback.
+            """
             unit_id = unit.get("id", "?")
             agentic_stats["errors"] += 1
             self._log("error", "Error processing unit", unit_id=unit_id, error=str(exc))

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -38,6 +38,7 @@ from typing import Callable, Optional
 
 from .file_io import read_json
 from .llm_client import TokenTracker, get_global_tracker, create_anthropic_client, create_message
+from .parallel_executor import run_parallel
 
 # Null logger that discards all messages (used when no logger provided)
 _null_logger = logging.getLogger("null_verifier")
@@ -417,6 +418,7 @@ class FindingVerifier:
         code_by_route: dict,
         progress_callback: Optional[Callable] = None,
         checkpoint_path: str | None = None,
+        concurrency: int = 4,
     ) -> list:
         """
         Verify a batch of results with consistency cross-check.
@@ -457,59 +459,74 @@ class FindingVerifier:
                 completed_keys = set()
 
         # Step 1: Individual verification
-        for i, result in enumerate(results):
+        # Report resumed findings
+        pending_results = []
+        for result in results:
             route_key = result.get("route_key", "unknown")
-
             if route_key in completed_keys:
-                # Already verified in previous run
                 if progress_callback:
                     progress_callback(route_key, "(resumed)", 0.0)
-                continue
+            else:
+                pending_results.append(result)
 
+        self._log("info", f"Verifying {len(pending_results)} findings (concurrency={concurrency})")
+
+        def _verify_one(result):
+            """Verify a single finding (called from worker thread)."""
+            route_key = result.get("route_key", "unknown")
+            stage1_finding = result.get("finding", "inconclusive")
+            code = code_by_route.get(route_key, "")
+            verification = self.verify_result(
+                code=code,
+                finding=stage1_finding,
+                attack_vector=result.get("attack_vector"),
+                reasoning=result.get("reasoning", ""),
+                files_included=result.get("files_included", [])
+            )
+            return verification
+
+        def _on_complete(result, verification):
+            """Called under lock after successful verification."""
+            route_key = result.get("route_key", "unknown")
             stage1_finding = result.get("finding", "inconclusive")
 
-            self._log("info", f"Verifying finding {i+1}/{len(results)}",
-                      unit_id=route_key, classification=stage1_finding)
+            result["verification"] = verification.to_dict()
 
-            unit_start = time.monotonic()
-            detail = ""
-            try:
-                code = code_by_route.get(route_key, "")
-                verification = self.verify_result(
-                    code=code,
-                    finding=stage1_finding,
-                    attack_vector=result.get("attack_vector"),
-                    reasoning=result.get("reasoning", ""),
-                    files_included=result.get("files_included", [])
-                )
+            if verification.agree:
+                detail = f"agreed:{verification.correct_finding}"
+                self._log("info", f"Verification agreed: {verification.correct_finding}",
+                          unit_id=route_key, total_tokens=verification.total_tokens,
+                          iterations=verification.iterations)
+            else:
+                detail = f"disagreed:{stage1_finding}->{verification.correct_finding}"
+                result["finding"] = verification.correct_finding
+                result["verification_note"] = f"Changed from {stage1_finding} to {verification.correct_finding}"
+                self._log("info", f"Verification disagreed: {stage1_finding} -> {verification.correct_finding}",
+                          unit_id=route_key, total_tokens=verification.total_tokens,
+                          iterations=verification.iterations)
 
-                result["verification"] = verification.to_dict()
-
-                if verification.agree:
-                    detail = f"agreed:{verification.correct_finding}"
-                    self._log("info", f"Verification agreed: {verification.correct_finding}",
-                              unit_id=route_key, total_tokens=verification.total_tokens,
-                              iterations=verification.iterations)
-                else:
-                    detail = f"disagreed:{stage1_finding}->{verification.correct_finding}"
-                    result["finding"] = verification.correct_finding
-                    result["verification_note"] = f"Changed from {stage1_finding} to {verification.correct_finding}"
-                    self._log("info", f"Verification disagreed: {stage1_finding} -> {verification.correct_finding}",
-                              unit_id=route_key, total_tokens=verification.total_tokens,
-                              iterations=verification.iterations)
-
-            except Exception as e:
-                detail = "error"
-                self._log("error", f"Verification failed", unit_id=route_key, error=str(e))
-
-            # Save checkpoint after each finding
             if checkpoint_path:
                 completed_keys.add(route_key)
                 _save_verify_checkpoint(checkpoint_path, results, completed_keys)
-
-            unit_elapsed = time.monotonic() - unit_start
             if progress_callback:
-                progress_callback(route_key, detail, unit_elapsed)
+                progress_callback(route_key, detail, 0.0)
+
+        def _on_error(result, exc):
+            """Called under lock when verification raises."""
+            route_key = result.get("route_key", "unknown")
+            self._log("error", f"Verification failed", unit_id=route_key, error=str(exc))
+            # Do NOT add to completed_keys — errored findings will be
+            # retried on resume (matching analyze/enhance behavior).
+            if progress_callback:
+                progress_callback(route_key, "error", 0.0)
+
+        run_parallel(
+            items=pending_results,
+            process_fn=_verify_one,
+            concurrency=concurrency,
+            on_complete=_on_complete,
+            on_error=_on_error,
+        )
 
         # Step 2: Consistency cross-check runs on ALL results (including resumed ones)
         results = self._check_consistency(results, code_by_route)

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -473,6 +473,7 @@ class FindingVerifier:
 
         def _verify_one(result):
             """Verify a single finding (called from worker thread)."""
+            start = time.monotonic()
             route_key = result.get("route_key", "unknown")
             stage1_finding = result.get("finding", "inconclusive")
             code = code_by_route.get(route_key, "")
@@ -483,10 +484,11 @@ class FindingVerifier:
                 reasoning=result.get("reasoning", ""),
                 files_included=result.get("files_included", [])
             )
-            return verification
+            return (verification, time.monotonic() - start)
 
-        def _on_complete(result, verification):
+        def _on_complete(result, verify_output):
             """Called under lock after successful verification."""
+            verification, unit_elapsed = verify_output
             route_key = result.get("route_key", "unknown")
             stage1_finding = result.get("finding", "inconclusive")
 
@@ -509,7 +511,7 @@ class FindingVerifier:
                 completed_keys.add(route_key)
                 _save_verify_checkpoint(checkpoint_path, results, completed_keys)
             if progress_callback:
-                progress_callback(route_key, detail, 0.0)
+                progress_callback(route_key, detail, unit_elapsed)
 
         def _on_error(result, exc):
             """Called under lock when verification raises."""
@@ -517,6 +519,9 @@ class FindingVerifier:
             self._log("error", f"Verification failed", unit_id=route_key, error=str(exc))
             # Do NOT add to completed_keys — errored findings will be
             # retried on resume (matching analyze/enhance behavior).
+            # We intentionally skip checkpoint save here: the last successful
+            # _on_complete already persisted all completed work. If the process
+            # dies after this error, the errored finding is simply reprocessed.
             if progress_callback:
                 progress_callback(route_key, "error", 0.0)
 

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -24,9 +24,13 @@ Usage:
 
 import os
 import sys
+import threading
 from typing import Optional
 import anthropic
 from dotenv import load_dotenv
+
+# Load .env once at module level (not thread-safe if called per-thread)
+load_dotenv()
 
 from .local_claude import LocalClaudeClient, is_enabled as _use_local_claude
 
@@ -46,6 +50,7 @@ class TokenTracker:
     """
 
     def __init__(self):
+        self._lock = threading.Lock()
         self.reset()
 
     def reset(self):
@@ -87,11 +92,12 @@ class TokenTracker:
             "cost_usd": round(total_cost, 6)
         }
 
-        # Update totals
-        self.calls.append(call_record)
-        self.total_input_tokens += input_tokens
-        self.total_output_tokens += output_tokens
-        self.total_cost_usd += total_cost
+        # Update totals (thread-safe for concurrent LLM calls)
+        with self._lock:
+            self.calls.append(call_record)
+            self.total_input_tokens += input_tokens
+            self.total_output_tokens += output_tokens
+            self.total_cost_usd += total_cost
 
         return call_record
 
@@ -102,14 +108,15 @@ class TokenTracker:
         Returns:
             Dict with totals and per-call breakdown
         """
-        return {
-            "total_calls": len(self.calls),
-            "total_input_tokens": self.total_input_tokens,
-            "total_output_tokens": self.total_output_tokens,
-            "total_tokens": self.total_input_tokens + self.total_output_tokens,
-            "total_cost_usd": round(self.total_cost_usd, 6),
-            "calls": self.calls
-        }
+        with self._lock:
+            return {
+                "total_calls": len(self.calls),
+                "total_input_tokens": self.total_input_tokens,
+                "total_output_tokens": self.total_output_tokens,
+                "total_tokens": self.total_input_tokens + self.total_output_tokens,
+                "total_cost_usd": round(self.total_cost_usd, 6),
+                "calls": list(self.calls)
+            }
 
     def get_totals(self) -> dict:
         """
@@ -118,13 +125,14 @@ class TokenTracker:
         Returns:
             Dict with totals only
         """
-        return {
-            "total_calls": len(self.calls),
-            "total_input_tokens": self.total_input_tokens,
-            "total_output_tokens": self.total_output_tokens,
-            "total_tokens": self.total_input_tokens + self.total_output_tokens,
-            "total_cost_usd": round(self.total_cost_usd, 6)
-        }
+        with self._lock:
+            return {
+                "total_calls": len(self.calls),
+                "total_input_tokens": self.total_input_tokens,
+                "total_output_tokens": self.total_output_tokens,
+                "total_tokens": self.total_input_tokens + self.total_output_tokens,
+                "total_cost_usd": round(self.total_cost_usd, 6)
+            }
 
 
 # Global tracker instance for session-wide tracking
@@ -189,8 +197,6 @@ class AnthropicClient:
                    Use "claude-sonnet-4-20250514" for cost-effective option.
             tracker: Optional TokenTracker instance. Uses global tracker if not provided.
         """
-        load_dotenv()
-
         self.client = create_anthropic_client()
         self.model = model
         self.tracker = tracker or _global_tracker

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -29,7 +29,10 @@ from typing import Optional
 import anthropic
 from dotenv import load_dotenv
 
-# Load .env once at module level (not thread-safe if called per-thread)
+# Load .env once at module level. Previously called in AnthropicClient.__init__,
+# but load_dotenv() mutates os.environ which is not thread-safe under concurrent
+# client construction. Runs at import time — tests that need to control env
+# should mock os.environ or patch before importing this module.
 load_dotenv()
 
 from .local_claude import LocalClaudeClient, is_enabled as _use_local_claude

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -57,11 +57,16 @@ class TokenTracker:
         self.reset()
 
     def reset(self):
-        """Reset all counters."""
-        self.calls = []
-        self.total_input_tokens = 0
-        self.total_output_tokens = 0
-        self.total_cost_usd = 0.0
+        """Reset all counters.
+
+        Acquires the lock to avoid racing with concurrent record_call().
+        Typically called between pipeline stages, not during.
+        """
+        with self._lock:
+            self.calls = []
+            self.total_input_tokens = 0
+            self.total_output_tokens = 0
+            self.total_cost_usd = 0.0
 
     @property
     def total_tokens(self) -> int:

--- a/libs/openant-core/utilities/parallel_executor.py
+++ b/libs/openant-core/utilities/parallel_executor.py
@@ -1,0 +1,115 @@
+"""Parallel executor for I/O-bound LLM workloads.
+
+Provides a reusable ``run_parallel()`` helper that wraps
+``concurrent.futures.ThreadPoolExecutor`` with:
+
+  - Lock-protected ``on_complete`` / ``on_error`` callbacks (safe for
+    checkpoint writes and shared-state mutations).
+  - Graceful ``KeyboardInterrupt`` handling (cancels queued futures,
+    re-raises promptly).
+  - A ``concurrency=1`` fast-path that runs items serially with no
+    thread pool overhead.
+"""
+
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Optional
+
+
+def run_parallel(
+    items: list,
+    process_fn: Callable[[Any], Any],
+    concurrency: int = 4,
+    on_complete: Optional[Callable[[Any, Any], None]] = None,
+    on_error: Optional[Callable[[Any, Exception], None]] = None,
+) -> list[tuple[Any, Any]]:
+    """Process *items* through *process_fn*, up to *concurrency* at a time.
+
+    Args:
+        items: Work items to process.
+        process_fn: ``(item) -> result``.  Called once per item, potentially
+            from a worker thread.
+        concurrency: Maximum number of concurrent workers.  ``1`` disables
+            threading entirely (serial execution, zero overhead).
+        on_complete: ``(item, result) -> None``.  Called under a shared lock
+            after *process_fn* returns successfully.  Use this for checkpoint
+            writes and shared-state mutations.
+        on_error: ``(item, exception) -> None``.  Called under the same lock
+            when *process_fn* raises.  Should also checkpoint if needed.
+
+    Returns:
+        List of ``(item, result)`` tuples for successful items (in
+        completion order).
+
+    Raises:
+        KeyboardInterrupt: Re-raised after cancelling queued futures.
+    """
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be >= 1, got {concurrency}")
+
+    if not items:
+        return []
+
+    # --- Serial fast-path (concurrency == 1) ---
+    if concurrency == 1:
+        return _run_serial(items, process_fn, on_complete, on_error)
+
+    # --- Parallel path ---
+    return _run_threaded(items, process_fn, concurrency, on_complete, on_error)
+
+
+def _run_serial(items, process_fn, on_complete, on_error):
+    """Run items one at a time with no threading."""
+    results = []
+    for item in items:
+        try:
+            result = process_fn(item)
+        except Exception as exc:
+            if on_error:
+                on_error(item, exc)
+            continue
+        if on_complete:
+            on_complete(item, result)
+        results.append((item, result))
+    return results
+
+
+def _run_threaded(items, process_fn, concurrency, on_complete, on_error):
+    """Run items across a thread pool with lock-protected callbacks."""
+    lock = threading.Lock()
+    results = []
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        future_to_item = {
+            executor.submit(process_fn, item): item for item in items
+        }
+
+        try:
+            for future in as_completed(future_to_item):
+                item = future_to_item[future]
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    with lock:
+                        if on_error:
+                            on_error(item, exc)
+                    continue
+
+                with lock:
+                    if on_complete:
+                        on_complete(item, result)
+                results.append((item, result))
+
+        except KeyboardInterrupt:
+            # Cancel queued (not-yet-started) futures; don't wait for
+            # in-flight HTTP calls.
+            executor.shutdown(wait=False, cancel_futures=True)
+            print(
+                "\n[parallel] Interrupted — checkpoint is valid, "
+                "resume will skip completed units.",
+                file=sys.stderr,
+            )
+            raise
+
+    return results

--- a/libs/openant-core/utilities/parallel_executor.py
+++ b/libs/openant-core/utilities/parallel_executor.py
@@ -62,16 +62,24 @@ def run_parallel(
 def _run_serial(items, process_fn, on_complete, on_error):
     """Run items one at a time with no threading."""
     results = []
-    for item in items:
-        try:
-            result = process_fn(item)
-        except Exception as exc:
-            if on_error:
-                on_error(item, exc)
-            continue
-        if on_complete:
-            on_complete(item, result)
-        results.append((item, result))
+    try:
+        for item in items:
+            try:
+                result = process_fn(item)
+            except Exception as exc:
+                if on_error:
+                    on_error(item, exc)
+                continue
+            if on_complete:
+                on_complete(item, result)
+            results.append((item, result))
+    except KeyboardInterrupt:
+        print(
+            "\n[parallel] Interrupted — checkpoint is valid, "
+            "resume will skip completed units.",
+            file=sys.stderr,
+        )
+        raise
     return results
 
 

--- a/libs/openant-core/utilities/parallel_executor.py
+++ b/libs/openant-core/utilities/parallel_executor.py
@@ -99,7 +99,7 @@ def _run_threaded(items, process_fn, concurrency, on_complete, on_error):
                 with lock:
                     if on_complete:
                         on_complete(item, result)
-                results.append((item, result))
+                    results.append((item, result))
 
         except KeyboardInterrupt:
             # Cancel queued (not-yet-started) futures; don't wait for


### PR DESCRIPTION
## Summary

- Add `ThreadPoolExecutor`-based parallelization to all three LLM stages (Enhance, Analyze, Verify) with lock-protected checkpoint writes that preserve full resume correctness
- New `--concurrency`/`-j` flag (default: 4) on `scan`, `enhance`, `analyze`, `verify` commands (Go + Python CLI)
- Fix pre-existing bug where verify checkpoint marked errored findings as completed, preventing retry on resume

## Changes

### New file
- `utilities/parallel_executor.py` � reusable `run_parallel()` with lock-protected `on_complete`/`on_error` callbacks, `KeyboardInterrupt` handling, and `concurrency=1` serial fast-path

### Thread safety (prerequisites)
- `TokenTracker`: lock on `record_call()`, `get_totals()`, `get_summary()`
- `ProgressReporter`: lock on `report()` to prevent interleaved output
- `load_dotenv()` moved to module-level in `llm_client.py`

### Stage parallelization
- **Analyze**: per-thread `AnthropicClient` + `JSONCorrector` via `threading.local()`; results sorted by `unit_id`
- **Enhance**: `enhance_unit_with_agent()` returns patch dict; mutations applied under lock
- **Verify**: `verify_batch()` uses `run_parallel()`; `_check_consistency()` remains serial

### Bug fix
- `finding_verifier.py`: errored findings no longer added to `completed_keys`

### CLI plumbing
- `--concurrency`/`-j` on Go + Python CLI with `>= 1` validation

## Test plan

- [x] All 203 tests pass including 13 new parallel_executor tests
- [x] Go CLI builds clean
- [ ] Run scan with `--concurrency 4` vs serial and compare
- [ ] Kill mid-scan, resume, verify checkpoint integrity

<details>
<summary>Full design document (MULTITHREAD.md)</summary>

# Plan: Parallelize LLM Calls Without Breaking Resume

## Context

OpenAnt processes LLM calls serially — one unit at a time in for-loops across three stages (Enhance, Analyze, Verify). Since these calls are I/O-bound (waiting on Anthropic API responses), parallelizing them can provide ~3-4x throughput improvement. The challenge is preserving the checkpoint/resume system that saves progress after each unit.

## Approach: `ThreadPoolExecutor` + Lock-Protected Checkpoints

**Why threads:** LLM calls are I/O-bound (network wait). The `anthropic` SDK uses `httpx` which is thread-safe. No GIL contention. `asyncio` would require rewriting the entire call chain; multiprocessing would require serializing heavy objects across processes. Threads are a drop-in change at the loop level.

**Resume safety:** Each unit's completion triggers an immediate checkpoint write under a `threading.Lock`. If the process dies, all completed units (from any thread) are already checkpointed. `atomic_write_json()` prevents corrupt checkpoint files. On resume, `completed_ids` / `completed_keys` sets skip already-done units — this is order-independent.

## Compatibility with Recent Changes

The `auto-retry errored units` feature (`3f6087a`) added `skip_errors` to analyze and enhance. This only affects the **pre-loop checkpoint loading** (filtering out errored results from `completed_ids`). The actual per-unit processing loop is unchanged. The `skip_errors` parameter will be threaded alongside `concurrency` — no conflict.

## Pre-existing Bug Fix (Verify checkpoint marks errors as completed)

**Bug:** `finding_verifier.py:505-508` — when `verify_result()` throws an exception, the code falls through to unconditionally add `route_key` to `completed_keys` and save checkpoint. Errored findings are permanently marked as "completed" and will never be retried on resume.

**Fix (prerequisite):** Move the `completed_keys.add(route_key)` and checkpoint save inside the `try` block (after successful verification), and add a separate error-handling path that checkpoints the error result explicitly (matching how `analyzer.py:249-254` handles errors with `verdict: ERROR`). This aligns verify with the analyze/enhance pattern and enables the same `skip_errors` retry behavior to be extended to verify in the future.

## Changes

### 1. New file: `libs/openant-core/utilities/parallel_executor.py` (~100 lines)

Reusable parallel runner used by all three stages:

```python
def run_parallel(
    items: list,
    process_fn: Callable[[Any], Any],
    concurrency: int = 4,
    on_complete: Callable[[Any, Any], None] | None = None,
    on_error: Callable[[Any, Exception], None] | None = None,
) -> list[tuple[Any, Any]]:
```

- Uses `ThreadPoolExecutor(max_workers=concurrency)`
- Submits all items as futures
- As each future completes (`as_completed`), calls `on_complete` or `on_error` under a shared `threading.Lock`
- The lock ensures checkpoint writes and shared-state mutations are serialized
- **Both `on_complete` and `on_error` callbacks run under the lock** — `on_error` must also checkpoint to match current analyze behavior where ERROR results are persisted
- Returns list of `(item, result)` tuples
- When `concurrency=1`, runs serially without a thread pool (preserves exact current behavior)
- **Graceful Ctrl+C handling:** Catches `KeyboardInterrupt` in the main iteration loop, calls `executor.shutdown(wait=False, cancel_futures=True)` to cancel queued futures, then re-raises. In-flight HTTP calls (up to `concurrency` of them) may still complete in the background, but the process exits promptly. The checkpoint is always valid at this point because completed units were already checkpointed under the lock. On resume, any units whose in-flight calls were interrupted are simply reprocessed.

### 2. Make `TokenTracker` thread-safe: `libs/openant-core/utilities/llm_client.py` (~10 lines)

- Add `self._lock = threading.Lock()` in `__init__` / `reset`
- Wrap the mutation block in `record_call()` with `with self._lock:`
- **Also wrap `get_totals()` and `get_summary()` with `with self._lock:`** — without this, a concurrent `get_totals()` call (e.g., from `ProgressReporter._get_cost()`) could read partially-updated state (e.g., `total_input_tokens` incremented but `total_cost_usd` not yet updated)

### 3. Make `ProgressReporter` thread-safe: `libs/openant-core/core/progress.py` (~5 lines)

- Add `self._lock = threading.Lock()` in `__init__`
- Wrap `report()` body with `with self._lock:` to prevent interleaved output and counter races

### 4. Parallelize Analyze stage: `libs/openant-core/core/analyzer.py` (~30 lines changed)

**Current** (line 229-260): `for i, unit in enumerate(units):` serial loop
**New:** Extract per-unit work into a `_analyze_one(unit)` function, use `run_parallel()`. The `on_complete` callback appends to `results`, updates `counts` and `code_by_route`, saves checkpoint, and reports progress — all under the lock. The `on_error` callback appends an ERROR result dict and saves checkpoint (matching current behavior at line 249-258).

**Thread safety:** Create a **new `AnthropicClient` and `JSONCorrector` per thread** rather than sharing the single instances. The shared client has a `self.last_call` attribute (`llm_client.py:212`) that is written on every `_call()` invocation — this would race under concurrent threads. `JSONCorrector` holds a reference to the client it was constructed with (`json_corrector.py:136`), so it must also be per-thread. Each `AnthropicClient` creates its own underlying `anthropic.Anthropic()` connection, which is lightweight (httpx manages connection pooling). The shared `TokenTracker` (via `get_global_tracker()`) is safe because we're adding a lock to it in change #2.

**`load_dotenv()` dedup:** `AnthropicClient.__init__` calls `load_dotenv()` on every construction (`llm_client.py:192`). With per-thread clients, this runs N times concurrently. `load_dotenv()` is idempotent but not thread-safe (reads `.env`, mutates `os.environ`). Move the `load_dotenv()` call to module-level or to a one-time initialization gate (e.g., `threading.once` or a module-level call) and remove it from `__init__`.

**Result ordering:** Results will be appended in completion order, not input order. Sort results by `unit_id` before writing `results.json` to ensure deterministic output regardless of concurrency level.

### 5. Parallelize Enhance stage: `libs/openant-core/utilities/context_enhancer.py` (~40 lines changed)

**Current** (line 443-486): `for i, unit in enumerate(units):` serial loop
**New:** Same pattern. Each thread calls `enhance_unit_with_agent()` which creates its own `ContextAgent` (and its own Anthropic client via `create_anthropic_client()`). `RepositoryIndex` is read-only — safe to share.

**Shared dataset mutation fix:** Currently `enhance_unit_with_agent(unit, ...)` mutates the unit dict in-place — not just `unit["agent_context"]` but also:
- `unit["code"]["primary_code"]` (assembled code with included functions, `agent.py:393`)
- `unit["code"]["primary_origin"]["files_included"]` (`agent.py:398`)
- `unit["code"]["primary_origin"]["enhanced"]` and `["enhanced_length"]` (`agent.py:399-400`)

The checkpoint serializes the entire `dataset` dict (which contains all units). Under concurrent threads, one thread could be mutating a unit while another is serializing the dataset for checkpoint.

**Solution:** Refactor `enhance_unit_with_agent()` to return a patch dict `(agent_context, code_patches)` rather than mutating the unit directly. The `on_complete` callback (running under the lock) applies all mutations to the unit dict AND then saves the checkpoint. This ensures the dataset is never read for serialization while a unit is being mutated. The `code_patches` dict captures `primary_code`, `primary_origin` updates so they can be applied atomically under the lock.

The `processed_this_run` counter (line 442) is replaced by the `on_complete` callback pattern — no separate counter needed.

### 6. Parallelize Verify stage: `libs/openant-core/utilities/finding_verifier.py` (~30 lines changed)

**Current** (line 460-511): `for i, result in enumerate(results):` serial loop
**New:** Same pattern. Each thread calls `self.verify_result()`. The shared `self.client` (raw `anthropic.Anthropic`, not `AnthropicClient`) is thread-safe — it has no `last_call` attribute. `on_complete` updates `completed_keys`, mutates the result dict, and saves checkpoint — all under the lock. The post-loop `_check_consistency()` call remains serial (runs after all parallel work completes).

### 7. Add `--concurrency` / `-j` CLI flag

**Python CLI:** `openant/cli.py` — add `--concurrency` / `-j` argument (default: 4) to `scan`, `enhance`, `analyze`, `verify` subcommands.

**Go CLI:** `apps/openant-cli/cmd/scan.go`, `enhance.go`, `analyze.go`, `verify.go` — add `--concurrency` / `-j` Cobra flag (int, default 4) and append `--concurrency <N>` to `pyArgs` when invoking Python subprocess. Follow the existing pattern used by `--skip-errors`.

**Thread through:** Go CLI -> Python CLI -> `scanner.py` -> each stage wrapper -> inner processing function.

`concurrency=1` gives exact serial behavior (backward compatible), with results sorted to match serial output ordering.

**Input validation:** Both Go and Python CLIs must validate `concurrency >= 1`. Python: `argparse` `type=int` with a custom validator or a post-parse check that raises `ArgumentError`. Go: validate before invoking Python. `ThreadPoolExecutor(max_workers=0)` raises `ValueError`, so this must be caught at the CLI layer with a clear error message.

## Files to Modify

| File | Change |
|------|--------|
| `libs/openant-core/utilities/parallel_executor.py` | **NEW** — reusable parallel runner with lock-protected callbacks |
| `libs/openant-core/utilities/llm_client.py` | Add `threading.Lock` to `TokenTracker` (reads AND writes); move `load_dotenv()` to module-level |
| `libs/openant-core/core/progress.py` | Add `threading.Lock` to `ProgressReporter.report()` |
| `libs/openant-core/utilities/finding_verifier.py` | Fix error checkpoint bug; use `run_parallel()` in `verify_batch()` |
| `libs/openant-core/core/analyzer.py` | Use `run_parallel()` with per-thread `AnthropicClient` + `JSONCorrector`; sort results before write |
| `libs/openant-core/utilities/context_enhancer.py` | Use `run_parallel()`; return patch dict instead of mutating in-place |
| `libs/openant-core/utilities/agentic_enhancer/agent.py` | Refactor `enhance_unit_with_agent()` to return patch dict instead of mutating unit |
| `libs/openant-core/core/enhancer.py` | Pass `concurrency` through to context_enhancer |
| `libs/openant-core/core/verifier.py` | Pass `concurrency` through to finding_verifier |
| `libs/openant-core/core/scanner.py` | Accept and forward `concurrency` parameter |
| `libs/openant-core/openant/cli.py` | Add `--concurrency`/`-j` flag to relevant subcommands |
| `apps/openant-cli/cmd/scan.go` | Add `--concurrency`/`-j` Cobra flag, pass to Python |
| `apps/openant-cli/cmd/enhance.go` | Add `--concurrency`/`-j` Cobra flag, pass to Python |
| `apps/openant-cli/cmd/analyze.go` | Add `--concurrency`/`-j` Cobra flag, pass to Python |
| `apps/openant-cli/cmd/verify.go` | Add `--concurrency`/`-j` Cobra flag, pass to Python |

## Resume Correctness & Graceful Shutdown

The key invariant is preserved: **a unit is checkpointed if and only if its processing completed (successfully or with an explicit error result).**

- Thread A finishes unit 5, acquires lock, appends result, writes checkpoint `{1,2,3,5}`
- Thread B finishes unit 4, acquires lock, appends result, writes checkpoint `{1,2,3,4,5}`
- If process dies between these: checkpoint has `{1,2,3,5}`. On resume, unit 4 + remaining units are reprocessed. Unit 5 is correctly skipped.
- `atomic_write_json()` (already used by all checkpoints) prevents partial/corrupt files

**Kill scenarios:**
- **SIGKILL / hard crash:** Checkpoint is valid (atomic writes). Up to `concurrency` in-flight units lose their token spend but are safely reprocessed on resume.
- **Ctrl+C (SIGINT):** `parallel_executor` catches `KeyboardInterrupt`, cancels queued futures via `shutdown(wait=False, cancel_futures=True)`, and re-raises. The process exits promptly without waiting for in-flight HTTP calls. Checkpoint is valid — all previously completed units are preserved.
- **Token waste on kill:** At most `concurrency` units may have partially consumed tokens without being checkpointed. With `concurrency=4` (default), this is at most 4 units of wasted API cost — same magnitude as the serial case (1 unit max) but bounded.

## Known Limitations

- **`os.replace()` on Windows:** `atomic_write_json` uses `os.replace()` which is atomic on POSIX but can raise `PermissionError` on Windows if an external process (editor, antivirus) has the target file open. The thread lock serializes writes within the process, but external file locks remain a risk. This is a pre-existing limitation (not introduced by parallelization).

- **`LocalClaudeClient` + concurrency:** When `OPENANT_LOCAL_CLAUDE=true`, each thread spawns a separate `claude -p` subprocess. This is heavyweight (N concurrent CLI startups) and may hit local session or rate limits. Mitigation: log a warning when local mode is detected with `concurrency > 1`, and document that users should use `--concurrency 1` (or omit the flag) in local mode. Do not silently override the user's concurrency setting.

- **Verbose/debug output interleaving:** In the enhance stage, `ContextAgent.analyze_unit()` prints debug output directly to stderr when `verbose=True` (`agent.py:280-281` area). These prints happen during the thread's processing phase (outside the lock), so they will interleave under `concurrency > 1`. The `ProgressReporter` lock only protects progress lines, not arbitrary stderr writes from within worker threads. Accept the garbled output as a cosmetic limitation — verbose mode is a debug tool, not user-facing. No code change needed.

## Implementation Order

1. Fix verify checkpoint bug (prerequisite — correctness fix)
2. `TokenTracker` thread-safety with read+write locking (prerequisite)
3. Move `load_dotenv()` to module-level in `llm_client.py` (prerequisite)
4. `ProgressReporter` thread-safety (prerequisite)
5. Create `parallel_executor.py` with tests
6. Parallelize Analyze (per-thread `AnthropicClient` + `JSONCorrector`, sort results)
7. Refactor `enhance_unit_with_agent()` to return patch dict; parallelize Enhance
8. Parallelize Verify (multi-turn, shared raw client)
9. Wire `--concurrency` flag through Go CLI, Python CLI, and scanner
10. Add `LocalClaudeClient` concurrency warning
11. Sort results before writing in all stages for deterministic output

## Verification

1. Run existing resume tests: `pytest tests/test_resume_stage1.py tests/test_resume_stage2.py tests/test_resume_stage3.py`
2. Run existing skip-errors tests: `pytest tests/test_skip_errors.py`
3. Run a small scan with `--concurrency 4` and verify results match serial run (after sorting)
4. Kill process mid-scan, resume, verify checkpoint integrity and correct skip behavior
5. Run with `--concurrency 1` to confirm identical behavior to current code
6. Verify errored findings in verify stage are now retried on resume (bug fix validation)

</details>

Generated with [Claude Code](https://claude.com/claude-code)
