### PR TITLE
fix: include format-specific path key in ReportResult output

### DIFF
--- a/apps/openant-cli/cmd/report.go
+++ b/apps/openant-cli/cmd/report.go
@@ -56,7 +56,16 @@ func runReport(cmd *cobra.Command, args []string) {
 	// Apply project defaults
 	if ctx != nil {
 		if reportOutput == "" {
-			reportOutput = filepath.Join(ctx.ScanDir, "report")
+			switch reportFormat {
+			case "summary":
+				reportOutput = filepath.Join(ctx.ScanDir, "SUMMARY_REPORT.md")
+			case "disclosure":
+				reportOutput = filepath.Join(ctx.ScanDir, "disclosures")
+			case "csv":
+				reportOutput = filepath.Join(ctx.ScanDir, "report.csv")
+			default:
+				reportOutput = filepath.Join(ctx.ScanDir, "report.html")
+			}
 		}
 		if reportPipelineOutput == "" {
 			reportPipelineOutput = ctx.scanFile("pipeline_output.json")

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -106,7 +106,17 @@ class ReportResult:
     format: str = "html"
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        d = asdict(self)
+        # Add format-specific path key expected by the Go CLI formatter
+        fmt_key = {
+            "html": "html_path",
+            "csv": "csv_path",
+            "summary": "summary_path",
+            "disclosure": "disclosure_path",
+        }.get(self.format)
+        if fmt_key:
+            d[fmt_key] = self.output_path
+        return d
 
 
 @dataclass

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -446,7 +446,12 @@ def cmd_report(args):
                 _output_json(error(f"Unknown format: {fmt}"))
                 return 2
 
-            ctx.summary = {"format": fmt}
+            summary = {"format": fmt}
+            if pipeline_output_path and os.path.isfile(pipeline_output_path):
+                po = read_json(pipeline_output_path)
+                summary["findings_count"] = len(po.get("findings", []))
+                summary["results"] = po.get("results", {})
+            ctx.summary = summary
             ctx.outputs = {"output_path": output_path}
 
         _output_json(success(result.to_dict()))


### PR DESCRIPTION
## Summary
- `ReportResult.to_dict()` returned only `output_path`, but the Go CLI formatter (`PrintReportSummary`) expects format-specific keys (`summary_path`, `html_path`, `csv_path`) — caused the "Reports Generated" section to display empty
- `report.report.json` summary only contained `{"format": "summary"}` with no findings data — now reads `pipeline_output.json` to include `findings_count` and result verdicts
- The report command used a single default output path (`report`) for all formats, causing conflicts when switching formats (e.g., summary created a file, then disclosure failed trying to mkdir on it) — now uses format-specific defaults: `SUMMARY_REPORT.md`, `disclosures/`, `report.csv`, `report.html`

## Test plan
- [ ] Run `openant report -f summary` and verify the "Reports Generated" section shows the summary path
- [ ] Run `openant report -f disclosure` and verify it creates a `disclosures/` directory without conflict
- [ ] Check `report.report.json` contains `findings_count` and `results` in summary field
- [ ] Run `openant report -f html` and verify HTML path default is `report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)