### PR TITLE
feat: add --fresh flag to parse command

### DIFF
--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -26,12 +26,14 @@ var (
 	parseOutput   string
 	parseLanguage string
 	parseLevel    string
+	parseFresh    bool
 )
 
 func init() {
 	parseCmd.Flags().StringVarP(&parseOutput, "output", "o", "", "Output directory (default: project scan dir)")
 	parseCmd.Flags().StringVarP(&parseLanguage, "language", "l", "", "Language: python, javascript, go, c, ruby, php, auto")
 	parseCmd.Flags().StringVar(&parseLevel, "level", "reachable", "Processing level: all, reachable, codeql, exploitable")
+	parseCmd.Flags().BoolVar(&parseFresh, "fresh", false, "Delete existing dataset and reparse from scratch")
 }
 
 func runParse(cmd *cobra.Command, args []string) {
@@ -83,6 +85,9 @@ func runParse(cmd *cobra.Command, args []string) {
 		pyArgs = append(pyArgs, "--language", parseLanguage)
 	}
 	pyArgs = append(pyArgs, "--level", parseLevel)
+	if parseFresh {
+		pyArgs = append(pyArgs, "--fresh")
+	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, resolvedAPIKey())
 	if err != nil {

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -74,6 +74,7 @@ def parse_repository(
     processing_level: str = "reachable",
     skip_tests: bool = True,
     name: str = None,
+    fresh: bool = False,
 ) -> ParseResult:
     """Parse a repository into an OpenAnt dataset.
 
@@ -87,6 +88,8 @@ def parse_repository(
         processing_level: "all", "reachable", "codeql", or "exploitable".
         skip_tests: If True, exclude test files from parsing (default: True).
         name: Dataset name override (default: derived from repo path basename).
+        fresh: If True, delete existing dataset.json before parsing so all
+            units are regenerated from scratch.
 
     Returns:
         ParseResult with paths to generated files and stats.
@@ -98,6 +101,12 @@ def parse_repository(
     repo_path = os.path.abspath(repo_path)
     output_dir = os.path.abspath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
+
+    if fresh:
+        dataset_path = os.path.join(output_dir, "dataset.json")
+        if os.path.exists(dataset_path):
+            os.remove(dataset_path)
+            print("[Parser] --fresh: deleted existing dataset.json", file=sys.stderr)
 
     # Detect language if auto
     if language == "auto":

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -201,10 +201,10 @@ def scan_repository(
     # Reset tracking
     tracking.reset_tracking()
 
-    # If fresh, delete all checkpoint files up front
+    # If fresh, delete all checkpoint and dataset files up front
     if fresh:
         for cp_name in ["enhance_checkpoint.json", "analyze_checkpoint.json",
-                        "verify_checkpoint.json"]:
+                        "verify_checkpoint.json", "dataset.json"]:
             cp_path = os.path.join(output_dir, cp_name)
             if os.path.exists(cp_path):
                 os.remove(cp_path)

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -112,6 +112,7 @@ def cmd_parse(args):
                 processing_level=args.level,
                 skip_tests=not args.no_skip_tests,
                 name=getattr(args, "name", None),
+                fresh=getattr(args, "fresh", False),
             )
 
             ctx.summary = {
@@ -565,6 +566,8 @@ def main():
     )
     parse_p.add_argument("--no-skip-tests", action="store_true", help="Include test files in parsing (default: tests are skipped)")
     parse_p.add_argument("--name", help="Dataset name (default: derived from repo path)")
+    parse_p.add_argument("--fresh", action="store_true",
+                         help="Delete existing dataset and reparse from scratch (default: reuse existing units)")
     parse_p.set_defaults(func=cmd_parse)
 
     # ---------------------------------------------------------------

--- a/libs/openant-core/parsers/javascript/unit_generator.js
+++ b/libs/openant-core/parsers/javascript/unit_generator.js
@@ -416,6 +416,9 @@ if (require.main === module) {
                 console.error(`  Existing units: ${existingUnits.length}`);
                 console.error(`  New units to add: ${newUnits.length}`);
                 console.error(`  Duplicates skipped: ${duplicateCount}`);
+                if (duplicateCount > 0) {
+                    console.error(`  Note: ${duplicateCount} existing units kept as-is (use --fresh to regenerate all units)`);
+                }
 
                 // Append new units to existing
                 finalResult = {


### PR DESCRIPTION
## Summary

- The parse step's unit generator merges new units into an existing dataset, preserving old units as-is. This means parser improvements (e.g., better call graph resolution) don't take effect for previously-parsed units unless the dataset is manually deleted.
- Add `--fresh` flag to `openant parse` to force a full reparse
- Ensure `openant scan --fresh` also clears the dataset alongside checkpoints
- Add a stderr note in the unit generator when existing units are being reused, pointing users to `--fresh`

## Test plan

- [x] All 203 existing tests pass
- [x] `openant parse --fresh` deletes existing dataset.json and regenerates all units
- [ ] `openant scan --fresh` includes dataset.json in cleanup
- [x] Unit generator prints note when skipping duplicate units

🤖 Generated with [Claude Code](https://claude.com/claude-code)