### PR TITLE
fix: pass --fresh flag to chained verify in analyze command

### DIFF
--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -253,6 +253,7 @@ def cmd_analyze(args):
                         app_context_path=args.app_context,
                         repo_path=args.repo_path,
                         concurrency=concurrency,
+                        fresh=args.fresh,
                     )
 
                     vctx.summary = {


### PR DESCRIPTION
## Summary
- Forward `fresh=args.fresh` to the `run_verification()` call in the `--verify` chaining block of the analyze command
- Without this fix, `openant analyze --verify --fresh` would re-run analyze but skip verify with "Already complete"

## Test plan
- [ ] Run `openant analyze --verify --fresh` with existing results — both stages should re-run
- [ ] Run `openant analyze --verify` without `--fresh` with existing results — verify should show "Already complete"
- [ ] Run `openant verify --fresh` standalone — should still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)