### PR TITLE
refactor: centralize model IDs into model_config.py

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -33,6 +33,7 @@ from dotenv import load_dotenv
 
 from utilities.file_io import read_json, write_json
 from utilities.llm_client import create_anthropic_client, create_message
+from utilities.model_config import MODEL_AUXILIARY
 
 # Load environment variables
 load_dotenv()
@@ -464,7 +465,7 @@ Respond with a JSON object (no other text):
 
 def generate_application_context(
     repo_path: Path,
-    model: str = "claude-sonnet-4-20250514",
+    model: str = MODEL_AUXILIARY,
     force_regenerate: bool = False,
 ) -> ApplicationContext:
     """Generate application context using LLM analysis.

--- a/libs/openant-core/context/generate_context.py
+++ b/libs/openant-core/context/generate_context.py
@@ -14,6 +14,7 @@ from pathlib import Path
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utilities.model_config import MODEL_AUXILIARY
 from context.application_context import (
     ApplicationType,
     APPLICATION_TYPE_INFO,
@@ -78,8 +79,8 @@ Manual Override:
 
     parser.add_argument(
         "--model", "-m",
-        default="claude-sonnet-4-20250514",
-        help="Anthropic model to use (default: claude-sonnet-4-20250514)",
+        default=MODEL_AUXILIARY,
+        help=f"Anthropic model to use (default: {MODEL_AUXILIARY})",
     )
 
     parser.add_argument(

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -167,7 +167,8 @@ def run_analysis(
     tracking.reset_tracking()
 
     # Select model
-    model_id = "claude-opus-4-6" if model == "opus" else "claude-sonnet-4-20250514"
+    from utilities.model_config import MODEL_AUXILIARY, MODEL_PRIMARY
+    model_id = MODEL_PRIMARY if model == "opus" else MODEL_AUXILIARY
     print(f"[Analyze] Model: {model_id}", file=sys.stderr)
 
     # Initialize client

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -101,7 +101,8 @@ def enhance_dataset(
                     usage=UsageInfo(),
                 )
 
-    model_id = "claude-sonnet-4-20250514" if model == "sonnet" else "claude-opus-4-6"
+    from utilities.model_config import MODEL_AUXILIARY, MODEL_PRIMARY
+    model_id = MODEL_AUXILIARY if model == "sonnet" else MODEL_PRIMARY
     print(f"[Enhance] Mode: {mode}", file=sys.stderr)
     print(f"[Enhance] Model: {model_id}", file=sys.stderr)
 

--- a/libs/openant-core/experiment.py
+++ b/libs/openant-core/experiment.py
@@ -467,7 +467,8 @@ def run_experiment(
         Experiment results with metrics
     """
     # Select model
-    model_id = "claude-opus-4-20250514" if model == "opus" else "claude-sonnet-4-20250514"
+    from utilities.model_config import MODEL_AUXILIARY, MODEL_PRIMARY
+    model_id = MODEL_PRIMARY if model == "opus" else MODEL_AUXILIARY
     print(f"Using model: {model_id}")
     print(f"Enhanced context: {enhanced}")
     print(f"Context correction: {correct_context}")

--- a/libs/openant-core/generate_report.py
+++ b/libs/openant-core/generate_report.py
@@ -30,7 +30,6 @@ import os
 import sys
 from datetime import datetime
 
-import anthropic
 from dotenv import load_dotenv
 from utilities.file_io import read_json
 
@@ -38,7 +37,8 @@ from utilities.file_io import read_json
 load_dotenv()
 
 
-REPORT_MODEL = "claude-sonnet-4-20250514"
+from utilities.model_config import MODEL_AUXILIARY
+REPORT_MODEL = MODEL_AUXILIARY
 MAX_TOKENS = 4096
 
 

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -14,7 +14,8 @@ from utilities.llm_client import create_anthropic_client, create_message
 load_dotenv()
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
-MODEL = "claude-opus-4-6"
+from utilities.model_config import MODEL_PRIMARY
+MODEL = MODEL_PRIMARY
 
 
 def _check_api_key():

--- a/libs/openant-core/tests/test_token_tracker.py
+++ b/libs/openant-core/tests/test_token_tracker.py
@@ -1,5 +1,6 @@
 """Tests for TokenTracker."""
 from utilities.llm_client import TokenTracker, MODEL_PRICING
+from utilities.model_config import MODEL_PRIMARY, MODEL_AUXILIARY
 
 
 class TestTokenTracker:
@@ -13,9 +14,9 @@ class TestTokenTracker:
 
     def test_record_call_known_model(self):
         tracker = TokenTracker()
-        result = tracker.record_call("claude-sonnet-4-20250514", 1000, 500)
+        result = tracker.record_call(MODEL_AUXILIARY, 1000, 500)
 
-        assert result["model"] == "claude-sonnet-4-20250514"
+        assert result["model"] == MODEL_AUXILIARY
         assert result["input_tokens"] == 1000
         assert result["output_tokens"] == 500
         # Sonnet: $3/M input, $15/M output
@@ -31,8 +32,8 @@ class TestTokenTracker:
 
     def test_cumulative_tracking(self):
         tracker = TokenTracker()
-        tracker.record_call("claude-sonnet-4-20250514", 1000, 500)
-        tracker.record_call("claude-sonnet-4-20250514", 2000, 1000)
+        tracker.record_call(MODEL_AUXILIARY, 1000, 500)
+        tracker.record_call(MODEL_AUXILIARY, 2000, 1000)
 
         assert tracker.total_input_tokens == 3000
         assert tracker.total_output_tokens == 1500
@@ -41,7 +42,7 @@ class TestTokenTracker:
 
     def test_reset(self):
         tracker = TokenTracker()
-        tracker.record_call("claude-sonnet-4-20250514", 1000, 500)
+        tracker.record_call(MODEL_AUXILIARY, 1000, 500)
         tracker.reset()
 
         assert tracker.total_input_tokens == 0
@@ -51,7 +52,7 @@ class TestTokenTracker:
 
     def test_get_summary_includes_calls(self):
         tracker = TokenTracker()
-        tracker.record_call("claude-sonnet-4-20250514", 100, 50)
+        tracker.record_call(MODEL_AUXILIARY, 100, 50)
         summary = tracker.get_summary()
 
         assert summary["total_calls"] == 1
@@ -60,7 +61,7 @@ class TestTokenTracker:
 
     def test_get_totals_excludes_calls(self):
         tracker = TokenTracker()
-        tracker.record_call("claude-sonnet-4-20250514", 100, 50)
+        tracker.record_call(MODEL_AUXILIARY, 100, 50)
         totals = tracker.get_totals()
 
         assert totals["total_calls"] == 1
@@ -68,6 +69,6 @@ class TestTokenTracker:
 
     def test_opus_pricing(self):
         tracker = TokenTracker()
-        result = tracker.record_call("claude-opus-4-20250514", 1_000_000, 1_000_000)
+        result = tracker.record_call(MODEL_PRIMARY, 1_000_000, 1_000_000)
         # Opus: $15/M input, $75/M output
         assert result["cost_usd"] == 90.0

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -17,6 +17,7 @@ import sys
 from typing import Optional
 
 from .llm_client import AnthropicClient, TokenTracker, get_global_tracker
+from .model_config import MODEL_AUXILIARY
 
 
 # Maximum characters per batch (leaving room for prompt overhead)
@@ -102,7 +103,7 @@ def parse_missing_context_with_llm(
     prompt = get_missing_context_prompt(reasoning)
 
     try:
-        llm_response = client.analyze_sync(prompt, model="claude-sonnet-4-20250514")
+        llm_response = client.analyze_sync(prompt, model=MODEL_AUXILIARY)
         parsed = _parse_json_response(llm_response)
 
         if parsed and "missing_context" in parsed:
@@ -254,7 +255,7 @@ def search_files_for_context(
         prompt = get_file_search_prompt(missing_context, files_content, batch_info)
 
         try:
-            response = client.analyze_sync(prompt, model="claude-sonnet-4-20250514")
+            response = client.analyze_sync(prompt, model=MODEL_AUXILIARY)
             result = _parse_json_response(response)
 
             if result and result.get("found_files"):

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -34,7 +34,8 @@ _null_logger.addHandler(logging.NullHandler())
 
 
 # Use Sonnet for context enhancement (cost-effective auxiliary task)
-CONTEXT_ENHANCEMENT_MODEL = "claude-sonnet-4-20250514"
+from .model_config import MODEL_AUXILIARY
+CONTEXT_ENHANCEMENT_MODEL = MODEL_AUXILIARY
 
 
 def get_context_enhancement_prompt(
@@ -404,7 +405,7 @@ class ContextEnhancer:
         remaining = total - len(processed_ids)
         self._log("info", f"Enhancing {remaining} units with agentic analysis ({len(processed_ids)} already done)", units=remaining)
         self._log("info", "Mode: Iterative tool use (traces call paths)")
-        self._log("info", "Model: claude-sonnet-4-20250514")
+        self._log("info", f"Model: {CONTEXT_ENHANCEMENT_MODEL}")
         if checkpoint_path:
             self._log("info", f"Checkpoint: {checkpoint_path}")
 

--- a/libs/openant-core/utilities/context_reviewer.py
+++ b/libs/openant-core/utilities/context_reviewer.py
@@ -13,6 +13,7 @@ import sys
 from typing import Optional
 
 from .llm_client import AnthropicClient
+from .model_config import MODEL_AUXILIARY
 from .context_corrector import gather_source_files, search_files_for_context
 
 
@@ -176,7 +177,7 @@ class ContextReviewer:
         prompt = get_context_review_prompt(code, route, handler, files_included)
 
         try:
-            response = self.client.analyze_sync(prompt, model="claude-sonnet-4-20250514")
+            response = self.client.analyze_sync(prompt, model=MODEL_AUXILIARY)
             review = self._parse_json_response(response)
 
             if not review:

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -12,7 +12,8 @@ import re
 
 from utilities.llm_client import AnthropicClient, TokenTracker
 
-SONNET_MODEL = "claude-sonnet-4-20250514"
+from ..model_config import MODEL_AUXILIARY
+SONNET_MODEL = MODEL_AUXILIARY
 
 # Map language strings to Dockerfile template names
 LANGUAGE_MAP = {

--- a/libs/openant-core/utilities/ground_truth_challenger.py
+++ b/libs/openant-core/utilities/ground_truth_challenger.py
@@ -19,6 +19,7 @@ from typing import Optional
 from dataclasses import dataclass
 
 from .llm_client import AnthropicClient
+from .model_config import MODEL_AUXILIARY
 
 
 @dataclass
@@ -209,13 +210,13 @@ class GroundTruthChallenger:
     2. Validate false negatives - did the model miss something, or is the ground truth wrong?
     """
 
-    def __init__(self, client: AnthropicClient, model: str = "claude-sonnet-4-20250514"):
+    def __init__(self, client: AnthropicClient, model: str = MODEL_AUXILIARY):
         """
         Initialize the challenger.
 
         Args:
             client: Anthropic client for LLM calls
-            model: Model to use for arbitration (Sonnet for cost efficiency)
+            model: Model to use for arbitration.
         """
         self.client = client
         self.model = model

--- a/libs/openant-core/utilities/json_corrector.py
+++ b/libs/openant-core/utilities/json_corrector.py
@@ -16,6 +16,7 @@ import sys
 from typing import Optional
 
 from .llm_client import AnthropicClient
+from .model_config import MODEL_AUXILIARY
 
 
 def get_json_extraction_prompt(raw_response: str) -> str:
@@ -83,7 +84,7 @@ def extract_json_with_llm(
         # Use Sonnet for extraction (faster/cheaper)
         llm_response = client.analyze_sync(
             prompt,
-            model="claude-sonnet-4-20250514",
+            model=MODEL_AUXILIARY,
             max_tokens=2048
         )
         return _parse_json_response(llm_response)

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -15,7 +15,7 @@ Classes:
 Usage:
     from utilities.llm_client import AnthropicClient, get_global_tracker
 
-    client = AnthropicClient(model="claude-opus-4-20250514")
+    client = AnthropicClient(model="claude-opus-4-6")
     response = client.analyze_sync("Analyze this code...")
 
     tracker = get_global_tracker()
@@ -36,12 +36,13 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from .local_claude import LocalClaudeClient, is_enabled as _use_local_claude
+from .model_config import MODEL_PRIMARY, MODEL_AUXILIARY, MODEL_DEFAULT
 
 
 # Pricing per million tokens (as of December 2024)
 MODEL_PRICING = {
-    "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
-    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+    MODEL_PRIMARY: {"input": 15.00, "output": 75.00},
+    MODEL_AUXILIARY: {"input": 3.00, "output": 15.00},
     # Fallback for unknown models (use Sonnet pricing as conservative estimate)
     "default": {"input": 3.00, "output": 15.00}
 }
@@ -196,13 +197,12 @@ class AnthropicClient:
         Claude Code session's authentication instead of an API key.
     """
 
-    def __init__(self, model: str = "claude-opus-4-20250514", tracker: TokenTracker = None):
+    def __init__(self, model: str = MODEL_DEFAULT, tracker: TokenTracker = None):
         """
         Initialize the Anthropic client.
 
         Args:
-            model: Model identifier. Default is Claude Opus 4 (highest capability).
-                   Use "claude-sonnet-4-20250514" for cost-effective option.
+            model: Model identifier. Defaults to MODEL_DEFAULT from model_config.
             tracker: Optional TokenTracker instance. Uses global tracker if not provided.
         """
         self.client = create_anthropic_client()

--- a/libs/openant-core/utilities/model_config.py
+++ b/libs/openant-core/utilities/model_config.py
@@ -1,0 +1,15 @@
+"""
+Central model configuration.
+
+All Claude model IDs are defined here. Change these to update which models
+are used across the entire pipeline.
+"""
+
+# Primary model — high capability, used for critical analysis and verification
+MODEL_PRIMARY = "claude-opus-4-6"
+
+# Auxiliary model — cost-effective, used for enhancement, consistency, context
+MODEL_AUXILIARY = "claude-sonnet-4-6"
+
+# Default fallback when no model is specified
+MODEL_DEFAULT = MODEL_PRIMARY

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -18,7 +18,8 @@ from utilities.llm_client import AnthropicClient, TokenTracker
 
 
 # Use a cheaper/faster model for consistency checks
-CONSISTENCY_MODEL = "claude-sonnet-4-20250514"
+from .model_config import MODEL_AUXILIARY
+CONSISTENCY_MODEL = MODEL_AUXILIARY
 MAX_TOKENS = 4096
 
 


### PR DESCRIPTION
## Summary
- Add `utilities/model_config.py` with three constants: `MODEL_PRIMARY` (opus), `MODEL_AUXILIARY` (sonnet), `MODEL_DEFAULT`
- Replace hardcoded model ID strings across 15 files with imports from `model_config`
- Also updates model IDs from 4.0 generation (`claude-sonnet-4-20250514`) to 4.6 (`claude-sonnet-4-6`)

## Test plan
- [x] All 52 existing tests pass
- [x] Ruff lint clean
- [ ] Manual: run `openant scan` and verify correct model is used
- [ ] Manual: change `MODEL_PRIMARY` in `model_config.py` and verify it propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)