### PR TITLE
feat: add generate-context CLI command with auto-discovery

### DIFF
--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -70,6 +70,9 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 		if analyzeAnalyzerOutput == "" {
 			analyzeAnalyzerOutput = ctx.scanFile("analyzer_output.json")
 		}
+		if analyzeAppContext == "" {
+			analyzeAppContext = ctx.scanFile("application_context.json")
+		}
 		if analyzeRepoPath == "" {
 			analyzeRepoPath = ctx.RepoPath
 		}

--- a/apps/openant-cli/cmd/generatecontext.go
+++ b/apps/openant-cli/cmd/generatecontext.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/knostic/open-ant-cli/internal/output"
+	"github.com/knostic/open-ant-cli/internal/python"
+	"github.com/spf13/cobra"
+)
+
+var generateContextCmd = &cobra.Command{
+	Use:   "generate-context [repository-path]",
+	Short: "Generate application security context for a repository",
+	Long: `Generate analyzes a repository and produces an application_context.json
+file that describes the application type, trust boundaries, intended
+behaviors, and patterns that should not be flagged as vulnerabilities.
+
+This context is automatically used by the analyze and verify commands
+to reduce false positives.
+
+If no repository path is given, the active project is used (see: openant init).
+
+The command checks for a manual override file (OPENANT.md or OPENANT.json)
+in the repository root before falling back to LLM-based generation.
+Use --force to skip the manual override check.`,
+	Args: cobra.MaximumNArgs(1),
+	Run:  runGenerateContext,
+}
+
+var (
+	gcOutput    string
+	gcForce     bool
+	gcShowPrompt bool
+)
+
+func init() {
+	generateContextCmd.Flags().StringVarP(&gcOutput, "output", "o", "", "Output path (default: <scan-dir>/application_context.json or <repo>/application_context.json)")
+	generateContextCmd.Flags().BoolVar(&gcForce, "force", false, "Force regeneration, ignoring OPENANT.md override files")
+	generateContextCmd.Flags().BoolVar(&gcShowPrompt, "show-prompt", false, "Include formatted prompt text in output")
+}
+
+func runGenerateContext(cmd *cobra.Command, args []string) {
+	repoPath, ctx, err := resolveRepoArg(args)
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	// Apply project defaults
+	if ctx != nil {
+		if gcOutput == "" {
+			gcOutput = ctx.scanFile("application_context.json")
+		}
+	}
+
+	rt, err := ensurePython()
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	// Build Python CLI args
+	pyArgs := []string{"generate-context", repoPath}
+	if gcOutput != "" {
+		pyArgs = append(pyArgs, "--output", gcOutput)
+	}
+	if gcForce {
+		pyArgs = append(pyArgs, "--force")
+	}
+	if gcShowPrompt {
+		pyArgs = append(pyArgs, "--show-prompt")
+	}
+
+	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	if jsonOutput {
+		output.PrintJSON(result.Envelope)
+	} else if result.Envelope.Status == "success" {
+		if data, ok := result.Envelope.Data.(map[string]any); ok {
+			printGenerateContextSummary(data)
+		}
+	} else {
+		output.PrintErrors(result.Envelope.Errors)
+	}
+
+	os.Exit(result.ExitCode)
+}
+
+func printGenerateContextSummary(data map[string]any) {
+	output.PrintHeader("Application Context Generated")
+	if v, ok := data["application_type"].(string); ok {
+		output.PrintKeyValue("Type", v)
+	}
+	if v, ok := data["purpose"].(string); ok {
+		output.PrintKeyValue("Purpose", v)
+	}
+	if v, ok := data["confidence"].(float64); ok {
+		output.PrintKeyValue("Confidence", fmt.Sprintf("%.0f%%", v*100))
+	}
+	if v, ok := data["source"].(string); ok {
+		output.PrintKeyValue("Source", v)
+	}
+	if v, ok := data["app_context_path"].(string); ok {
+		output.PrintKeyValue("Output", v)
+	}
+	fmt.Println()
+}

--- a/apps/openant-cli/cmd/root.go
+++ b/apps/openant-cli/cmd/root.go
@@ -32,11 +32,12 @@ Stage 1: Detect potential vulnerabilities via code analysis
 Stage 2: Simulate an attacker to eliminate false positives
 
 Commands:
-  scan          Full pipeline: parse → enhance → detect → verify → report
-  parse         Extract code units from a repository
-  enhance       Add security context to a parsed dataset
-  analyze       Run Stage 1 vulnerability detection
-  verify        Run Stage 2 attacker simulation
+  scan              Full pipeline: parse → enhance → detect → verify → report
+  parse             Extract code units from a repository
+  generate-context  Generate application security context
+  enhance           Add security context to a parsed dataset
+  analyze           Run Stage 1 vulnerability detection
+  verify            Run Stage 2 attacker simulation
   build-output  Assemble pipeline_output.json from verified results
   dynamic-test  Docker-isolated exploit testing
   report        Generate reports from analysis results
@@ -98,6 +99,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(scanCmd)
 	rootCmd.AddCommand(parseCmd)
+	rootCmd.AddCommand(generateContextCmd)
 	rootCmd.AddCommand(enhanceCmd)
 	rootCmd.AddCommand(analyzeCmd)
 	rootCmd.AddCommand(verifyCmd)

--- a/apps/openant-cli/cmd/verify.go
+++ b/apps/openant-cli/cmd/verify.go
@@ -63,6 +63,9 @@ func runVerify(cmd *cobra.Command, args []string) {
 		if verifyAnalyzerOutput == "" {
 			verifyAnalyzerOutput = ctx.scanFile("analyzer_output.json")
 		}
+		if verifyAppContext == "" {
+			verifyAppContext = ctx.scanFile("application_context.json")
+		}
 		if verifyRepoPath == "" {
 			verifyRepoPath = ctx.RepoPath
 		}

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -5,6 +5,7 @@ OpenAnt CLI — Unified command-line interface for vulnerability analysis.
 Commands:
     openant scan /path/to/repo --output /tmp/results
     openant parse /path/to/repo --output /tmp/results
+    openant generate-context /path/to/repo -o /tmp/results/application_context.json
     openant enhance dataset.json --analyzer-output ao.json --repo-path /repo -o enhanced.json
     openant analyze dataset.json --output /tmp/results
     openant verify results.json --analyzer-output ao.json --output /tmp/results
@@ -29,6 +30,20 @@ def _output_json(data: dict):
     """Write JSON to stdout."""
     json.dump(data, sys.stdout, indent=2)
     sys.stdout.write("\n")
+
+
+def _find_app_context(*candidate_dirs: str) -> str | None:
+    """Search candidate directories for application_context.json.
+
+    Returns the first existing path, or None.
+    """
+    for d in candidate_dirs:
+        if not d:
+            continue
+        path = os.path.join(d, "application_context.json")
+        if os.path.isfile(path):
+            return path
+    return None
 
 
 def _validate_concurrency(value: int) -> int:
@@ -132,6 +147,57 @@ def cmd_parse(args):
         return 2
 
 
+def cmd_generate_context(args):
+    """Generate application security context for a repository."""
+    from pathlib import Path
+    from context.application_context import (
+        generate_application_context,
+        save_context,
+        format_context_for_prompt,
+    )
+    from core.schemas import success, error
+    from core.step_report import step_context
+
+    output_path = args.output or os.path.join(args.repo, "application_context.json")
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+
+    try:
+        with step_context("generate-context", output_dir, inputs={
+            "repo_path": os.path.abspath(args.repo),
+            "force": args.force,
+        }) as ctx:
+            app_context = generate_application_context(
+                Path(args.repo),
+                force_regenerate=args.force,
+            )
+            save_context(app_context, Path(output_path))
+
+            ctx.summary = {
+                "application_type": app_context.application_type,
+                "confidence": app_context.confidence,
+                "source": app_context.source,
+            }
+            ctx.outputs = {"app_context_path": os.path.abspath(output_path)}
+
+        result = {
+            "app_context_path": os.path.abspath(output_path),
+            "application_type": app_context.application_type,
+            "purpose": app_context.purpose,
+            "confidence": app_context.confidence,
+            "source": app_context.source,
+        }
+
+        if args.show_prompt:
+            result["prompt_format"] = format_context_for_prompt(app_context)
+
+        _output_json(success(result))
+        return 0
+
+    except Exception as e:
+        _output_json(error(str(e)))
+        return 2
+
+
 def cmd_enhance(args):
     """Enhance a dataset with security context."""
     from core.enhancer import enhance_dataset
@@ -196,6 +262,18 @@ def cmd_analyze(args):
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_analyze_")
 
+    # Auto-discover application context if not explicitly provided
+    app_context_path = args.app_context
+    if not app_context_path:
+        app_context_path = _find_app_context(
+            output_dir,
+            args.repo_path,
+            os.path.dirname(os.path.abspath(args.dataset)),
+        )
+        if app_context_path:
+            print(f"[Analyze] Auto-discovered application context: {app_context_path}",
+                  file=sys.stderr)
+
     try:
         concurrency = _validate_concurrency(args.concurrency)
         with step_context("analyze", output_dir, inputs={
@@ -208,7 +286,7 @@ def cmd_analyze(args):
                 dataset_path=args.dataset,
                 output_dir=output_dir,
                 analyzer_output_path=args.analyzer_output,
-                app_context_path=args.app_context,
+                app_context_path=app_context_path,
                 repo_path=args.repo_path,
                 limit=args.limit,
                 model=args.model,
@@ -249,7 +327,7 @@ def cmd_analyze(args):
                         results_path=result.results_path,
                         output_dir=output_dir,
                         analyzer_output_path=args.analyzer_output,
-                        app_context_path=args.app_context,
+                        app_context_path=app_context_path,
                         repo_path=args.repo_path,
                         concurrency=concurrency,
                         fresh=args.fresh,
@@ -291,19 +369,31 @@ def cmd_verify(args):
 
     output_dir = args.output or tempfile.mkdtemp(prefix="open_ant_verify_")
 
+    # Auto-discover application context if not explicitly provided
+    app_context_path = args.app_context
+    if not app_context_path:
+        app_context_path = _find_app_context(
+            output_dir,
+            args.repo_path,
+            os.path.dirname(os.path.abspath(args.results)),
+        )
+        if app_context_path:
+            print(f"[Verify] Auto-discovered application context: {app_context_path}",
+                  file=sys.stderr)
+
     try:
         concurrency = _validate_concurrency(args.concurrency)
         with step_context("verify", output_dir, inputs={
             "results_path": os.path.abspath(args.results),
             "analyzer_output_path": os.path.abspath(args.analyzer_output),
-            "app_context_path": os.path.abspath(args.app_context) if args.app_context else None,
+            "app_context_path": os.path.abspath(app_context_path) if app_context_path else None,
             "repo_path": os.path.abspath(args.repo_path) if args.repo_path else None,
         }) as ctx:
             result = run_verification(
                 results_path=args.results,
                 output_dir=output_dir,
                 analyzer_output_path=args.analyzer_output,
-                app_context_path=args.app_context,
+                app_context_path=app_context_path,
                 repo_path=args.repo_path,
                 fresh=args.fresh,
                 concurrency=concurrency,
@@ -569,6 +659,22 @@ def main():
     parse_p.add_argument("--fresh", action="store_true",
                          help="Delete existing dataset and reparse from scratch (default: reuse existing units)")
     parse_p.set_defaults(func=cmd_parse)
+
+    # ---------------------------------------------------------------
+    # generate-context — generate application security context
+    # ---------------------------------------------------------------
+    gc_p = subparsers.add_parser(
+        "generate-context",
+        help="Generate application security context for a repository",
+    )
+    gc_p.add_argument("repo", help="Path to repository")
+    gc_p.add_argument("--output", "-o",
+                       help="Output path (default: <repo>/application_context.json)")
+    gc_p.add_argument("--force", action="store_true",
+                       help="Force regeneration, ignoring OPENANT.md override files")
+    gc_p.add_argument("--show-prompt", action="store_true",
+                       help="Include formatted prompt text in output")
+    gc_p.set_defaults(func=cmd_generate_context)
 
     # ---------------------------------------------------------------
     # enhance — add security context to a dataset

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -416,6 +416,28 @@ class TestInit:
         assert "no supported source files" in (result.stderr + result.stdout).lower()
 
 
+class TestGenerateContextHelp:
+    """Tests for `openant generate-context --help`."""
+
+    def test_help(self):
+        result = run_cli("generate-context", "--help")
+        assert result.returncode == 0
+        output = result.stdout + result.stderr
+        assert "repository" in output.lower()
+        assert "context" in output.lower()
+
+
+class TestGenerateContext:
+    """Tests for `openant generate-context` (no API key)."""
+
+    def test_requires_api_key(self, sample_python_repo):
+        """generate-context should fail without an API key."""
+        result = run_cli("generate-context", sample_python_repo)
+        output = result.stderr + result.stdout
+        assert result.returncode != 0
+        assert "api key" in output.lower()
+
+
 class TestApiKeyHandling:
     def test_scan_requires_api_key(self, sample_python_repo):
         """Scan should fail without an API key."""


### PR DESCRIPTION
## Summary

- Add `openant generate-context [repo-path]` command (Go + Python) to generate `application_context.json` as a standalone pipeline step
- Fully integrated with the project system (`openant init` / `project switch`) — defaults output to the project scan directory
- Auto-discover `application_context.json` in `analyze` and `verify` commands (both Go and Python CLIs) so `--app-context` is no longer required when the file exists in the scan dir
- Add tests for help output and API key requirement

## Test plan

- [x] Go CLI compiles successfully
- [x] `openant generate-context --help` shows correct usage
- [x] `openant generate-context` without API key fails with helpful error
- [x] All 30 existing + new Go CLI tests pass
- [x] Python CLI `generate-context --help` shows correct args
- [x] `analyze --help` and `verify --help` unchanged
- [ ] Manual: `openant generate-context` with active project writes to scan dir
- [ ] Manual: `openant analyze` auto-discovers context from scan dir
- [ ] Manual: `--force` skips OPENANT.md override
- [ ] Manual: `--show-prompt` includes formatted prompt in output

<details>
<summary>Full implementation plan</summary>

# Plan: Add openant generate-context CLI Command + Auto-Discovery

## Context

When running the pipeline as individual steps (not openant scan), there is no way to generate the application_context.json file via the CLI. The scan command auto-generates it, but analyze and verify only accept a pre-generated file via --app-context. A standalone python -m context.generate_context script exists but is not integrated into the unified openant CLI.

The real entry point is the **Go CLI** (apps/openant-cli/), which handles project resolution (openant init / project switch) and delegates to the Python core. Each Go command uses resolveRepoArg() to get the repo path from a positional arg or the active project, defaults output to ctx.ScanDir, and calls python.Invoke().

This adds:
1. A Go + Python generate-context subcommand to generate application context as a discrete pipeline step, fully integrated with the project system
2. Auto-discovery of application_context.json in analyze and verify (both Go and Python sides) so users do not need --app-context every time

Note: The enhance step does not use application context — it does its own classification based on code and call graphs.

## Changes

### 1. Go CLI: New apps/openant-cli/cmd/generatecontext.go

Follow the parse.go / scan.go pattern:

- Command: generate-context [repository-path] (optional positional arg)
- Uses resolveRepoArg(args) to get repo path from arg or active project
- Flags: --output/-o, --force, --show-prompt
- When project context exists (ctx != nil): default output to ctx.ScanDir
- Builds Python args and calls python.Invoke()
- Handles JSON/human output like other commands

### 2. Go CLI: Register in apps/openant-cli/cmd/root.go

Add rootCmd.AddCommand(generateContextCmd) and update the Long description.

### 3. Go CLI: Auto-discover in apps/openant-cli/cmd/analyze.go

In runAnalyze, default analyzeAppContext to ctx.scanFile("application_context.json") when project context exists. Matches the existing pattern for analyzeAnalyzerOutput and analyzeRepoPath.

### 4. Go CLI: Auto-discover in apps/openant-cli/cmd/verify.go

Same pattern: default verifyAppContext to ctx.scanFile("application_context.json").

### 5. Python CLI: New cmd_generate_context in libs/openant-core/openant/cli.py

- Import generate_application_context, save_context, format_context_for_prompt
- Accept args.repo (positional), --output/-o, --force, --show-prompt
- Default output path: repo/application_context.json (fallback when Go CLI does not pass --output)
- Use step_context for consistency with other steps
- Output JSON via _output_json(success(...))

### 6. Python CLI: Register subparser in main()

Between parse and enhance blocks.

### 7. Python CLI: Auto-discover in cmd_analyze and cmd_verify

Add _find_app_context() helper that searches output dir, repo path, and input file dir. Log to stderr when auto-discovered.

### 8. Python CLI: Update module docstring

Add openant generate-context /path/to/repo to usage examples.

## Tests

### File: libs/openant-core/tests/test_go_cli.py

- TestGenerateContextHelp: confirm help output works
- TestGenerateContext: confirm API key requirement error

## Manual verification (requires API key)
1. openant generate-context with active project writes to scan dir
2. openant generate-context /path/to/repo -o /tmp/ctx.json works
3. openant analyze auto-discovers context from scan dir
4. openant verify auto-discovers context from scan dir
5. Explicit --app-context takes precedence
6. --force skips OPENANT.md override
7. --show-prompt includes formatted prompt
8. --json produces machine-readable output

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
