### PR TITLE
feat: add override merge mode for generate-context command

### DIFF
--- a/apps/openant-cli/cmd/generatecontext.go
+++ b/apps/openant-cli/cmd/generatecontext.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/knostic/open-ant-cli/internal/output"
 	"github.com/knostic/open-ant-cli/internal/python"
@@ -23,20 +26,31 @@ If no repository path is given, the active project is used (see: openant init).
 
 The command checks for a manual override file (OPENANT.md or OPENANT.json)
 in the repository root before falling back to LLM-based generation.
-Use --force to skip the manual override check.`,
+
+When an override file is found, you are prompted to choose how to handle it:
+  use    - Use the override file as-is (skip LLM generation)
+  merge  - Feed the override file into the LLM alongside other sources
+  ignore - Ignore the override and generate from scratch
+
+Use --override-mode to skip the prompt, or --force as a shortcut for --override-mode=ignore.`,
 	Args: cobra.MaximumNArgs(1),
 	Run:  runGenerateContext,
 }
 
 var (
-	gcOutput    string
-	gcForce     bool
-	gcShowPrompt bool
+	gcOutput       string
+	gcForce        bool
+	gcOverrideMode string
+	gcShowPrompt   bool
 )
+
+// overrideFiles lists manual override filenames checked in the target repo.
+var overrideFiles = []string{"OPENANT.md", "OPENANT.json", ".openant.md", ".openant.json"}
 
 func init() {
 	generateContextCmd.Flags().StringVarP(&gcOutput, "output", "o", "", "Output path (default: <scan-dir>/application_context.json or <repo>/application_context.json)")
 	generateContextCmd.Flags().BoolVar(&gcForce, "force", false, "Force regeneration, ignoring OPENANT.md override files")
+	generateContextCmd.Flags().StringVar(&gcOverrideMode, "override-mode", "", "How to handle OPENANT.md: use, merge, or ignore (skips interactive prompt)")
 	generateContextCmd.Flags().BoolVar(&gcShowPrompt, "show-prompt", false, "Include formatted prompt text in output")
 }
 
@@ -54,6 +68,13 @@ func runGenerateContext(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Resolve effective override mode
+	effectiveMode, err := resolveOverrideMode(repoPath)
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
 	rt, err := ensurePython()
 	if err != nil {
 		output.PrintError(err.Error())
@@ -65,8 +86,8 @@ func runGenerateContext(cmd *cobra.Command, args []string) {
 	if gcOutput != "" {
 		pyArgs = append(pyArgs, "--output", gcOutput)
 	}
-	if gcForce {
-		pyArgs = append(pyArgs, "--force")
+	if effectiveMode != "" {
+		pyArgs = append(pyArgs, "--override-mode", effectiveMode)
 	}
 	if gcShowPrompt {
 		pyArgs = append(pyArgs, "--show-prompt")
@@ -89,6 +110,88 @@ func runGenerateContext(cmd *cobra.Command, args []string) {
 	}
 
 	os.Exit(result.ExitCode)
+}
+
+// resolveOverrideMode determines the effective override mode based on flags
+// and interactive prompting.
+func resolveOverrideMode(repoPath string) (string, error) {
+	// --force and --override-mode are mutually exclusive
+	if gcForce && gcOverrideMode != "" {
+		return "", fmt.Errorf("--force and --override-mode are mutually exclusive")
+	}
+
+	// --force is a shortcut for --override-mode=ignore
+	if gcForce {
+		return "ignore", nil
+	}
+
+	// Explicit --override-mode takes precedence
+	if gcOverrideMode != "" {
+		mode := strings.ToLower(gcOverrideMode)
+		if mode != "use" && mode != "merge" && mode != "ignore" {
+			return "", fmt.Errorf("invalid --override-mode %q: must be use, merge, or ignore", gcOverrideMode)
+		}
+		return mode, nil
+	}
+
+	// No explicit flag — check for override file
+	overrideFile := findOverrideFile(repoPath)
+	if overrideFile == "" {
+		// No override file exists; let Python use default LLM generation
+		return "", nil
+	}
+
+	// Override file found — prompt if interactive, else default to "use"
+	if !isInteractiveTerminal() {
+		return "use", nil
+	}
+
+	return promptOverrideMode(overrideFile), nil
+}
+
+// findOverrideFile checks for manual override files in the repo root.
+// Returns the filename if found, empty string otherwise.
+func findOverrideFile(repoPath string) string {
+	for _, name := range overrideFiles {
+		path := filepath.Join(repoPath, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return name
+		}
+	}
+	return ""
+}
+
+// isInteractiveTerminal returns true if stdin is a terminal (not piped/CI).
+func isInteractiveTerminal() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// promptOverrideMode shows an interactive prompt for how to handle the override file.
+func promptOverrideMode(filename string) string {
+	fmt.Fprintf(os.Stderr, "\nFound manual override: %s\n\n", filename)
+	fmt.Fprintln(os.Stderr, "  [u]se    — Use as-is (skip LLM generation)")
+	fmt.Fprintln(os.Stderr, "  [m]erge  — Feed into LLM alongside other sources")
+	fmt.Fprintln(os.Stderr, "  [i]gnore — Ignore, generate from scratch")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprint(os.Stderr, "Choice [u/m/i] (default: u): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	switch answer {
+	case "m", "merge":
+		return "merge"
+	case "i", "ignore":
+		return "ignore"
+	default:
+		// "u", "use", or empty (default)
+		return "use"
+	}
 }
 
 func printGenerateContextSummary(data map[string]any) {

--- a/libs/openant-core/CLAUDE.md
+++ b/libs/openant-core/CLAUDE.md
@@ -55,6 +55,13 @@ python -m context.generate_context /path/to/repo --list-types  # Show supported 
 
 **Manual override:** Create `OPENANT.md` or `OPENANT.json` in repo root. See `context/OPENANT_TEMPLATE.md` for format.
 
+**Override modes:** When a manual override file is detected, the CLI prompts for how to handle it:
+- `use` — Use override as-is, skip LLM (default)
+- `merge` — Feed override into LLM alongside other sources
+- `ignore` — Ignore override, generate from scratch
+
+Use `--override-mode <mode>` to skip the prompt, or `--force` as shortcut for `--override-mode ignore`.
+
 **Unsupported types:** If a repository doesn't match supported types, OpenAnt exits with error code 2 and instructions for creating a manual override.
 
 # Autopilot (Autonomous Pipeline)

--- a/libs/openant-core/CURRENT_IMPLEMENTATION.md
+++ b/libs/openant-core/CURRENT_IMPLEMENTATION.md
@@ -251,6 +251,13 @@ python -m context.generate_context /path/to/repo
 
 **Manual Override:** Place `OPENANT.md` or `OPENANT.json` in repo root to provide explicit context. Manual overrides bypass type validation.
 
+**Override Modes:** When a manual override file is detected, the CLI prompts for how to handle it:
+- `use` — Use override as-is, skip LLM generation (default)
+- `merge` — Feed override content into LLM alongside other sources (source="merged")
+- `ignore` — Ignore override, generate from scratch
+
+Use `--override-mode <mode>` to skip the prompt, or `--force` as shortcut for `--override-mode ignore`.
+
 **Integration:** Context automatically loaded in `experiment.py` and injected into Stage 1 and Stage 2 prompts.
 
 **Results on LangChain:**

--- a/libs/openant-core/PIPELINE_MANUAL.md
+++ b/libs/openant-core/PIPELINE_MANUAL.md
@@ -575,7 +575,14 @@ python -m context.generate_context --list-types  # Show supported types
 
 **Manual Override:**
 
-Create `OPENANT.md` or `OPENANT.json` in repo root to override automatic detection.
+Create `OPENANT.md` or `OPENANT.json` in repo root to provide explicit context.
+
+When a manual override file is detected, the CLI prompts for how to handle it:
+- `use` — Use override as-is, skip LLM generation (default)
+- `merge` — Feed override content into LLM alongside other sources
+- `ignore` — Ignore override, generate from scratch
+
+Use `--override-mode <mode>` to skip the prompt, or `--force` as shortcut for `--override-mode ignore`.
 
 ---
 

--- a/libs/openant-core/context/OPENANT_TEMPLATE.md
+++ b/libs/openant-core/context/OPENANT_TEMPLATE.md
@@ -16,6 +16,13 @@ OpenAnt supports these four application types:
 
 **Note:** Manual overrides can use any `application_type` value (validation is skipped for manual overrides). Use this to analyze unsupported application types by mapping them to the closest supported type.
 
+**Override modes:** When this file is detected, the `generate-context` command prompts for how to handle it:
+- `use` — Use this file as-is, skip LLM generation (default)
+- `merge` — Feed this file into the LLM alongside other repo sources (README, etc.)
+- `ignore` — Ignore this file and generate context from scratch
+
+Use `--override-mode <mode>` to skip the prompt.
+
 ## Format
 
 Include a JSON code block with the following structure:

--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -195,16 +195,43 @@ ENTRY_POINT_PATTERNS = {
 }
 
 
-def gather_context_sources(repo_path: Path) -> dict[str, str]:
+def find_override_file(repo_path: Path) -> Path | None:
+    """Return path to first existing manual override file, or None.
+
+    Args:
+        repo_path: Path to repository root.
+
+    Returns:
+        Path to override file if found, None otherwise.
+    """
+    for filename in MANUAL_OVERRIDE_FILES:
+        filepath = repo_path / filename
+        if filepath.exists():
+            return filepath
+    return None
+
+
+def gather_context_sources(repo_path: Path, override_path: Path | None = None) -> dict[str, str]:
     """Gather relevant files for context generation.
 
     Args:
         repo_path: Path to the repository root.
+        override_path: Optional path to override file to include as a source.
 
     Returns:
         Dictionary mapping filename to content.
     """
     sources = {}
+
+    # Include override file content if provided (merge mode)
+    if override_path is not None:
+        try:
+            content = override_path.read_text(errors="ignore")
+            if len(content) > 10000:
+                content = content[:10000] + "\n\n[... truncated ...]"
+            sources[override_path.name] = content
+        except Exception as e:
+            print(f"Warning: Could not read {override_path.name}: {e}", file=sys.stderr)
 
     # Read priority files
     for filename in CONTEXT_FILES:
@@ -387,12 +414,21 @@ def _build_type_descriptions() -> str:
     return "\n".join(lines)
 
 
+MERGE_CONTEXT_SUPPLEMENT = """
+## Developer-Provided Context
+
+The repository maintainer provided a manual security context file (listed above
+in the sources). Treat their classification of intended behaviors, trust
+boundaries, and not-a-vulnerability entries as authoritative hints. Validate the
+application type against the other source files and reconcile any conflicts.
+"""
+
 CONTEXT_GENERATION_PROMPT = """Analyze this software repository and generate a security analysis context.
 
 ## Repository Information
 
 {sources}
-
+{developer_context}
 ---
 
 ## Task
@@ -467,6 +503,7 @@ def generate_application_context(
     repo_path: Path,
     model: str = MODEL_AUXILIARY,
     force_regenerate: bool = False,
+    override_mode: str | None = None,
 ) -> ApplicationContext:
     """Generate application context using LLM analysis.
 
@@ -475,7 +512,9 @@ def generate_application_context(
     Args:
         repo_path: Path to the repository root.
         model: Anthropic model to use for generation.
-        force_regenerate: If True, skip manual override check.
+        force_regenerate: If True, skip manual override check (legacy, use override_mode).
+        override_mode: How to handle override files: "use" (verbatim), "merge" (feed
+            into LLM), "ignore" (skip override), or None (legacy behavior).
 
     Returns:
         ApplicationContext with security-relevant information.
@@ -485,16 +524,29 @@ def generate_application_context(
     """
     repo_path = Path(repo_path)
 
-    # Check for manual override first
-    if not force_regenerate:
+    # Resolve effective mode from override_mode or legacy force_regenerate
+    if override_mode is None:
+        effective_mode = "ignore" if force_regenerate else "use"
+    else:
+        effective_mode = override_mode
+
+    # "use" mode: return manual override verbatim if found
+    if effective_mode == "use":
         manual_context = check_manual_override(repo_path)
         if manual_context:
-            print(f"Using manual override from repository", file=sys.stderr)
+            print("Using manual override from repository", file=sys.stderr)
             return manual_context
 
-    # Gather sources
+    # "merge" mode: find override file to include as LLM source
+    override_path = None
+    if effective_mode == "merge":
+        override_path = find_override_file(repo_path)
+        if override_path:
+            print(f"Merging {override_path.name} into LLM context", file=sys.stderr)
+
+    # Gather sources (includes override file in merge mode)
     print(f"Gathering context sources from {repo_path}...", file=sys.stderr)
-    sources = gather_context_sources(repo_path)
+    sources = gather_context_sources(repo_path, override_path=override_path)
 
     if not sources:
         raise ValueError(f"No context sources found in {repo_path}")
@@ -504,10 +556,16 @@ def generate_application_context(
     for name, content in sources.items():
         sources_text += f"\n### {name}\n```\n{content}\n```\n"
 
+    # Add developer context supplement when merging
+    developer_context = MERGE_CONTEXT_SUPPLEMENT if override_path else ""
+
     # Call LLM
     print(f"Generating context with {model}...", file=sys.stderr)
     response_text = create_message(
-        prompt=CONTEXT_GENERATION_PROMPT.format(sources=sources_text),
+        prompt=CONTEXT_GENERATION_PROMPT.format(
+            sources=sources_text,
+            developer_context=developer_context,
+        ),
         model=model,
     )
 
@@ -524,7 +582,7 @@ def generate_application_context(
     except json.JSONDecodeError as e:
         raise ValueError(f"Failed to parse LLM response as JSON: {e}\nResponse: {response_text}")
 
-    data['source'] = 'llm'
+    data['source'] = 'merged' if override_path else 'llm'
 
     # Validate and create context (will raise UnsupportedApplicationTypeError if invalid)
     return ApplicationContext(**data)

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -161,14 +161,23 @@ def cmd_generate_context(args):
     output_path = args.output or os.path.join(args.repo, "application_context.json")
     output_dir = os.path.dirname(os.path.abspath(output_path))
 
+    # Resolve effective override mode
+    if args.override_mode:
+        effective_mode = args.override_mode
+    elif args.force:
+        effective_mode = "ignore"
+    else:
+        effective_mode = None  # legacy default behavior
+
     try:
         with step_context("generate-context", output_dir, inputs={
             "repo_path": os.path.abspath(args.repo),
             "force": args.force,
+            "override_mode": effective_mode,
         }) as ctx:
             app_context = generate_application_context(
                 Path(args.repo),
-                force_regenerate=args.force,
+                override_mode=effective_mode,
             )
             save_context(app_context, Path(output_path))
 
@@ -672,6 +681,9 @@ def main():
                        help="Output path (default: <repo>/application_context.json)")
     gc_p.add_argument("--force", action="store_true",
                        help="Force regeneration, ignoring OPENANT.md override files")
+    gc_p.add_argument("--override-mode", choices=["use", "ignore", "merge"],
+                       default=None,
+                       help="How to handle OPENANT.md: use (as-is), merge (into LLM), ignore")
     gc_p.add_argument("--show-prompt", action="store_true",
                        help="Include formatted prompt text in output")
     gc_p.set_defaults(func=cmd_generate_context)

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -426,6 +426,12 @@ class TestGenerateContextHelp:
         assert "repository" in output.lower()
         assert "context" in output.lower()
 
+    def test_help_shows_override_mode(self):
+        result = run_cli("generate-context", "--help")
+        assert result.returncode == 0
+        output = result.stdout + result.stderr
+        assert "override-mode" in output
+
 
 class TestGenerateContext:
     """Tests for `openant generate-context` (no API key)."""
@@ -436,6 +442,16 @@ class TestGenerateContext:
         output = result.stderr + result.stdout
         assert result.returncode != 0
         assert "api key" in output.lower()
+
+    def test_force_and_override_mode_mutually_exclusive(self, sample_python_repo):
+        """--force and --override-mode together should error."""
+        result = run_cli(
+            "generate-context", sample_python_repo,
+            "--force", "--override-mode", "merge",
+        )
+        output = result.stderr + result.stdout
+        assert result.returncode != 0
+        assert "mutually exclusive" in output.lower()
 
 
 class TestApiKeyHandling:


### PR DESCRIPTION
## Summary

- When `generate-context` detects a manual override file (OPENANT.md/OPENANT.json), it now prompts the user to choose: **use** (as-is), **merge** (feed into LLM alongside other sources), or **ignore** (skip override)
- New `--override-mode <use|merge|ignore>` flag bypasses the interactive prompt for CI/automation
- `--force` kept as backward-compatible shortcut for `--override-mode ignore`

## Changed files

- **`apps/openant-cli/cmd/generatecontext.go`** — Interactive prompt, override file detection, `--override-mode` flag
- **`libs/openant-core/context/application_context.py`** — `find_override_file()`, `override_mode` param on `generate_application_context()`, merge prompt supplement in `gather_context_sources()`
- **`libs/openant-core/openant/cli.py`** — `--override-mode` argument, wiring to core
- **`libs/openant-core/tests/test_go_cli.py`** — Tests for new flag in help and mutual exclusion with `--force`
- **Docs** — CLAUDE.md, CURRENT_IMPLEMENTATION.md, PIPELINE_MANUAL.md, OPENANT_TEMPLATE.md

## Test plan

- [x] `go build` succeeds
- [x] All 32 integration tests pass (including 2 new tests)
- [ ] Manual: `openant generate-context <repo-with-OPENANT.md>` shows interactive prompt
- [ ] Manual: `--override-mode merge` feeds override into LLM (verify with `--show-prompt`)
- [ ] Manual: `--force --override-mode merge` returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)