### PR TITLE
docs: update PIPELINE_MANUAL.md for generate-context CLI command

### DIFF
--- a/libs/openant-core/CURRENT_IMPLEMENTATION.md
+++ b/libs/openant-core/CURRENT_IMPLEMENTATION.md
@@ -227,13 +227,17 @@ Unsupported types (desktop apps, mobile apps, games, embedded systems) are rejec
 
 **Usage:**
 ```bash
+# Generate context via CLI (recommended)
+openant generate-context /path/to/repo
+
+# Generate context via Python module
+python -m context.generate_context /path/to/repo
+
 # List supported types
 python -m context.generate_context --list-types
 
-# Generate context for a repository
-python -m context.generate_context /path/to/repo
-
-# Context is saved to application_context.json in the dataset directory
+# Context is saved to application_context.json in the scan/dataset directory
+# analyze and verify auto-discover it when using a project
 ```
 
 **Generated Context Structure:**

--- a/libs/openant-core/DOCUMENTATION.md
+++ b/libs/openant-core/DOCUMENTATION.md
@@ -221,7 +221,8 @@ For AI assistants working on the code, here are the key source files:
 | File | Purpose |
 |------|---------|
 | `context/application_context.py` | Context detection & formatting |
-| `context/generate_context.py` | CLI for context generation |
+| `context/generate_context.py` | Python module CLI for context generation |
+| `openant/cli.py` (`generate-context`) | Primary CLI command (`openant generate-context`) |
 
 ### Report Generator
 

--- a/libs/openant-core/PIPELINE_MANUAL.md
+++ b/libs/openant-core/PIPELINE_MANUAL.md
@@ -534,14 +534,25 @@ For typical web applications, entry-point filtering achieves 60-95% reduction.
 
 Classifies the repository type to reduce false positives.
 
-**Location:** `context/generate_context.py`
+**Location:** `context/application_context.py`, `openant/cli.py`
 
-**Command:**
+**Command (via CLI):**
+```bash
+openant generate-context                           # Uses active project
+openant generate-context /path/to/repo             # Explicit repo path
+openant generate-context /path/to/repo -o ctx.json # Custom output path
+openant generate-context --force                   # Skip OPENANT.md override
+openant generate-context --show-prompt             # Include prompt format in output
+```
+
+**Command (via Python module):**
 ```bash
 python -m context.generate_context /path/to/repo
 python -m context.generate_context /path/to/repo -o application_context.json
 python -m context.generate_context --list-types  # Show supported types
 ```
+
+When using a project (`openant init`), the output defaults to the project scan directory and is automatically discovered by `analyze` and `verify` — no need to pass `--app-context`.
 
 **Supported Application Types:**
 
@@ -892,7 +903,7 @@ python parsers/python/parse_repository.py /path/to/flask-app \
 python validate_dataset_schema.py datasets/flask-app/dataset.json
 
 # 3. Generate application context
-python -m context.generate_context /path/to/flask-app
+openant generate-context /path/to/flask-app
 
 # 4. Run Stage 1 + Stage 2 on first 20 units
 python experiment.py --dataset flask-app --verify --limit 20
@@ -914,7 +925,7 @@ python parsers/javascript/test_pipeline.py /path/to/node-app \
 python validate_dataset_schema.py datasets/node-app/dataset.json
 
 # 3. Generate application context
-python -m context.generate_context /path/to/node-app
+openant generate-context /path/to/node-app
 
 # 4. Run full analysis
 python experiment.py --dataset node-app --verify
@@ -960,7 +971,7 @@ python parsers/python/parse_repository.py /repo --output datasets/name/dataset.j
 python parsers/javascript/test_pipeline.py /repo --analyzer-path /analyzer.js --output datasets/name --processing-level codeql
 
 # Generate app context
-python -m context.generate_context /repo
+openant generate-context /repo
 
 # Run Stage 1
 python experiment.py --dataset name

--- a/libs/openant-core/README.md
+++ b/libs/openant-core/README.md
@@ -131,15 +131,17 @@ OpenAnt generates application context to understand what type of application is 
 ### Generate Context
 
 ```bash
-# Generate context for a repository
+# Generate context via CLI (recommended)
+openant generate-context /path/to/repo
+openant generate-context /path/to/repo --show-prompt  # Include prompt format
+openant generate-context --force                       # Skip OPENANT.md override
+
+# Generate context via Python module
 python -m context.generate_context /path/to/repo
-
-# View formatted prompt output
-python -m context.generate_context /path/to/repo --show-prompt
-
-# List supported types
-python -m context.generate_context --list-types
+python -m context.generate_context --list-types        # Show supported types
 ```
+
+When using a project (`openant init`), `analyze` and `verify` auto-discover the generated context — no need to pass `--app-context`.
 
 ### Manual Override
 


### PR DESCRIPTION
## Summary

- Update PIPELINE_MANUAL.md Step 4 to document `openant generate-context` as the primary CLI command
- Add note about auto-discovery in analyze/verify when using a project
- Keep `python -m context.generate_context` as secondary option
- Update all examples and quick reference to use the new command

## Test plan

- [x] Documentation changes only — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
