### PR TITLE
feat: add sdk_errors taxonomy for SDK-surfaced LLM errors

### DIFF
--- a/libs/openant-core/tests/test_sdk_errors.py
+++ b/libs/openant-core/tests/test_sdk_errors.py
@@ -1,0 +1,87 @@
+"""Tests for utilities.sdk_errors."""
+import pytest
+
+from utilities.sdk_errors import (
+    OpenAntLLMError,
+    AuthError,
+    BillingError,
+    RateLimitError,
+    InvalidRequestError,
+    ServerError,
+    UnknownLLMError,
+    error_from_kind,
+    classify_error,
+)
+
+
+class TestErrorFromKind:
+    def test_each_known_kind_maps_to_correct_class(self):
+        cases = [
+            ("authentication_failed", AuthError),
+            ("billing_error", BillingError),
+            ("rate_limit", RateLimitError),
+            ("invalid_request", InvalidRequestError),
+            ("server_error", ServerError),
+            ("unknown", UnknownLLMError),
+        ]
+        for kind, expected_cls in cases:
+            exc = error_from_kind(kind)
+            assert isinstance(exc, expected_cls), f"{kind} -> {type(exc).__name__}"
+            assert exc.error_kind == kind
+
+    def test_unrecognized_kind_falls_back_to_unknown(self):
+        exc = error_from_kind("not_a_real_kind")
+        assert isinstance(exc, UnknownLLMError)
+
+    def test_custom_message_used_when_provided(self):
+        exc = error_from_kind("rate_limit", "hit the limit")
+        assert "hit the limit" in str(exc)
+
+    def test_default_message_mentions_kind(self):
+        exc = error_from_kind("server_error")
+        assert "server_error" in str(exc)
+
+
+class TestClassifyError:
+    def test_rate_limit(self):
+        info = classify_error(RateLimitError("rate limit hit"))
+        assert info["type"] == "rate_limit"
+        assert info["exception_class"] == "RateLimitError"
+        assert "rate limit hit" in info["message"]
+
+    def test_auth_billing_server_invalid_request(self):
+        assert classify_error(AuthError())["type"] == "auth"
+        assert classify_error(BillingError())["type"] == "billing"
+        assert classify_error(ServerError())["type"] == "server"
+        assert classify_error(InvalidRequestError())["type"] == "invalid_request"
+
+    def test_non_llm_error_type_is_unknown_but_class_name_preserved(self):
+        info = classify_error(ValueError("bad"))
+        assert info["type"] == "unknown"
+        assert info["exception_class"] == "ValueError"
+
+    def test_agent_state_propagated(self):
+        exc = RateLimitError("hit limit")
+        exc.agent_state = {"iteration": 3, "tokens_used": 1234}
+        info = classify_error(exc)
+        assert info["agent_state"] == {"iteration": 3, "tokens_used": 1234}
+
+    def test_missing_agent_state_not_in_dict(self):
+        info = classify_error(RateLimitError())
+        assert "agent_state" not in info
+
+
+class TestOpenAntLLMError:
+    def test_kwargs_become_attributes(self):
+        exc = RateLimitError("msg", request_id="req-123", status_code=429)
+        assert exc.request_id == "req-123"
+        assert exc.status_code == 429
+
+    def test_message_attribute_mirrors_str(self):
+        exc = RateLimitError("hello")
+        assert exc.message == "hello"
+        assert str(exc) == "hello"
+
+    def test_can_be_raised_and_caught_as_base(self):
+        with pytest.raises(OpenAntLLMError):
+            raise RateLimitError("x")

--- a/libs/openant-core/utilities/sdk_errors.py
+++ b/libs/openant-core/utilities/sdk_errors.py
@@ -1,0 +1,141 @@
+"""SDK error taxonomy.
+
+Replaces the `anthropic.*Error` hierarchy that scattered through the codebase
+pre-migration. The Claude Agent SDK surfaces API-level errors through
+`AssistantMessage.error: AssistantMessageError | None`, a Literal of
+"authentication_failed", "billing_error", "rate_limit", "invalid_request",
+"server_error", "unknown". We map each one onto an exception class so callers
+can `except RateLimitError` instead of inspecting message fields.
+
+Process-level errors (CLI not found, connection issues, JSON decode failures)
+come through `claude_agent_sdk`'s own exception types and propagate up
+unwrapped — they're not API errors.
+"""
+
+from typing import Any
+
+
+class OpenAntLLMError(Exception):
+    """Base class for LLM-layer errors that originated inside the model turn.
+
+    Subclasses correspond 1:1 to `AssistantMessageError` literal values. Raised
+    from `utilities.llm_client._run_query` when an AssistantMessage carries an
+    `error` field.
+    """
+
+    error_kind: str = "unknown"
+
+    def __init__(self, message: str = "", **kwargs: Any):
+        super().__init__(message)
+        self.message = message
+        # Allow callers to attach arbitrary state (e.g. agent iteration counts).
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class AuthError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "authentication_failed"."""
+
+    error_kind = "authentication_failed"
+
+
+class BillingError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "billing_error"."""
+
+    error_kind = "billing_error"
+
+
+class RateLimitError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "rate_limit".
+
+    The SDK does not surface a `retry-after` value; callers that feed
+    GlobalRateLimiter should pass 0 and let the default backoff apply.
+    """
+
+    error_kind = "rate_limit"
+
+
+class InvalidRequestError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "invalid_request"."""
+
+    error_kind = "invalid_request"
+
+
+class ServerError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "server_error". Transient; safe to retry."""
+
+    error_kind = "server_error"
+
+
+class UnknownLLMError(OpenAntLLMError):
+    """Maps to AssistantMessageError == "unknown". Fallback for unrecognized values."""
+
+    error_kind = "unknown"
+
+
+# Dispatch table for AssistantMessageError literal -> exception class.
+_ERROR_KIND_TO_CLASS: dict[str, type[OpenAntLLMError]] = {
+    "authentication_failed": AuthError,
+    "billing_error": BillingError,
+    "rate_limit": RateLimitError,
+    "invalid_request": InvalidRequestError,
+    "server_error": ServerError,
+    "unknown": UnknownLLMError,
+}
+
+
+def error_from_kind(kind: str, message: str = "") -> OpenAntLLMError:
+    """Construct the right exception subclass for an AssistantMessageError value.
+
+    Unknown kinds fall back to UnknownLLMError.
+    """
+    cls = _ERROR_KIND_TO_CLASS.get(kind, UnknownLLMError)
+    return cls(message or f"SDK reported error: {kind}")
+
+
+def classify_error(exc: BaseException) -> dict:
+    """Return a diagnostic dict for an OpenAntLLMError (or any exception).
+
+    Shape matches what `utilities.context_enhancer` logged pre-migration, so
+    existing callers can swap to this function without reshaping downstream
+    consumers:
+
+        {
+            "type": "rate_limit" | "connection" | "timeout" | "api_status" | "unknown",
+            "exception_class": "RateLimitError",
+            "message": "...",
+            ...
+        }
+
+    The pre-migration shape also carried `status_code`, `request_id`, and
+    `retry_after` extracted from anthropic response headers. The SDK does not
+    surface any of those, so we drop them.
+    """
+    info: dict = {
+        "type": "unknown",
+        "exception_class": type(exc).__name__,
+        "message": str(exc),
+    }
+
+    if isinstance(exc, RateLimitError):
+        info["type"] = "rate_limit"
+    elif isinstance(exc, AuthError):
+        info["type"] = "auth"
+    elif isinstance(exc, BillingError):
+        info["type"] = "billing"
+    elif isinstance(exc, ServerError):
+        info["type"] = "server"
+    elif isinstance(exc, InvalidRequestError):
+        info["type"] = "invalid_request"
+    elif isinstance(exc, UnknownLLMError):
+        info["type"] = "unknown"
+    else:
+        # Non-LLM error (process-level, SDK framework, caller bug). Leave
+        # "type" as "unknown" but the class name still identifies it.
+        pass
+
+    agent_state = getattr(exc, "agent_state", None)
+    if agent_state:
+        info["agent_state"] = agent_state
+
+    return info


### PR DESCRIPTION
## Summary

Adds `libs/openant-core/utilities/sdk_errors.py`: a small exception taxonomy that maps `claude_agent_sdk`'s `AssistantMessageError` literal values onto Python exception classes. Prep work for completing the SDK migration — every subsequent step in that effort catches these classes.

## Why

Post-merge, four files still use `anthropic.*Error` types for rate-limit / connection / API-status handling. The Claude Agent SDK doesn't expose equivalent exception types — it surfaces errors via `AssistantMessage.error: AssistantMessageError | None` (a Literal of `authentication_failed`, `billing_error`, `rate_limit`, `invalid_request`, `server_error`, `unknown`). This taxonomy is what future ports will catch.

See `SDK_MIGRATION_COMPLETION_PLAN.md` for the full context.

## What's included

- `OpenAntLLMError` base + one subclass per `AssistantMessageError` value (`AuthError`, `BillingError`, `RateLimitError`, `InvalidRequestError`, `ServerError`, `UnknownLLMError`).
- `error_from_kind(kind, message)` factory that dispatches SDK literal strings to the right class.
- `classify_error(exc)` returning the diagnostic dict shape `context_enhancer.py` builds today (minus `request_id` and `retry_after`, which the SDK doesn't surface — acceptable trade-off per plan).

## Test plan

- [x] 12 unit tests covering dispatch, fallback for unknown kinds, kwargs-as-attributes, and agent-state propagation. All pass.
- [x] No existing files modified; no regression risk.
- [ ] Downstream consumers (Steps 2, 3, 4, 5a) will exercise the taxonomy end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)