### PR TITLE
refactor: port report/generator.py to Claude Agent SDK

### DIFF
--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -7,37 +7,34 @@ Returns (text, usage_dict) tuples from LLM functions so callers can track costs.
 import json
 import os
 import sys
-import anthropic
 from pathlib import Path
 from dotenv import load_dotenv
 
 from .schema import validate_pipeline_output, ValidationError
+from utilities.llm_client import AnthropicClient
 
 load_dotenv()
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 MODEL = "claude-opus-4-6"
 
-# Pricing per million tokens
-_PRICING = {
-    "claude-opus-4-6": {"input": 15.00, "output": 75.00},
-    "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
-    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
-}
-_DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
 
+def _usage_from_last_call(last_call: dict | None) -> dict:
+    """Adapt TokenTracker.record_call output to the report's usage shape.
 
-def _extract_usage(response, model: str = MODEL) -> dict:
-    """Extract usage info from an Anthropic API response."""
-    usage = response.usage
-    pricing = _PRICING.get(model, _DEFAULT_PRICING)
-    input_cost = (usage.input_tokens / 1_000_000) * pricing["input"]
-    output_cost = (usage.output_tokens / 1_000_000) * pricing["output"]
+    TokenTracker returns {model, input_tokens, output_tokens, cost_usd};
+    callers here want {input_tokens, output_tokens, total_tokens, cost_usd}.
+    Returns zeros when last_call is None (e.g. if the SDK didn't surface usage).
+    """
+    if not last_call:
+        return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cost_usd": 0.0}
+    it = last_call.get("input_tokens", 0)
+    ot = last_call.get("output_tokens", 0)
     return {
-        "input_tokens": usage.input_tokens,
-        "output_tokens": usage.output_tokens,
-        "total_tokens": usage.input_tokens + usage.output_tokens,
-        "cost_usd": round(input_cost + output_cost, 6),
+        "input_tokens": it,
+        "output_tokens": ot,
+        "total_tokens": it + ot,
+        "cost_usd": last_call.get("cost_usd", 0.0),
     }
 
 
@@ -135,20 +132,14 @@ def generate_summary_report(pipeline_data: dict) -> tuple[str, dict]:
         output_tokens, total_tokens, cost_usd.
     """
     _check_api_key()
-    client = anthropic.Anthropic()
+    client = AnthropicClient(model=MODEL)
 
     summary_data = _compact_for_summary(pipeline_data)
     system_prompt = load_prompt("system")
     user_prompt = load_prompt("summary").replace("{pipeline_data}", json.dumps(summary_data, indent=2))
 
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=4096,
-        system=system_prompt,
-        messages=[{"role": "user", "content": user_prompt}]
-    )
-
-    return response.content[0].text, _extract_usage(response)
+    text = client.analyze_sync(user_prompt, system=system_prompt, max_tokens=4096)
+    return text, _usage_from_last_call(client.get_last_call())
 
 
 def generate_disclosure(vulnerability_data: dict, product_name: str) -> tuple[str, dict]:
@@ -158,7 +149,7 @@ def generate_disclosure(vulnerability_data: dict, product_name: str) -> tuple[st
         (disclosure_text, usage_dict)
     """
     _check_api_key()
-    client = anthropic.Anthropic()
+    client = AnthropicClient(model=MODEL)
 
     system_prompt = load_prompt("system")
 
@@ -168,14 +159,8 @@ def generate_disclosure(vulnerability_data: dict, product_name: str) -> tuple[st
         json.dumps(vuln_with_product, indent=2)
     )
 
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=4096,
-        system=system_prompt,
-        messages=[{"role": "user", "content": user_prompt}]
-    )
-
-    return response.content[0].text, _extract_usage(response)
+    text = client.analyze_sync(user_prompt, system=system_prompt, max_tokens=4096)
+    return text, _usage_from_last_call(client.get_last_call())
 
 
 def generate_all(pipeline_path: str, output_dir: str) -> None:


### PR DESCRIPTION
## Summary

Replaces the two inline `anthropic.Anthropic()` sites in `report/generator.py` with `AnthropicClient` from `utilities.llm_client`. Step 6 of the SDK migration plan — the smallest of the four remaining anthropic-using files.

## Changes

- `generate_summary_report` / `generate_disclosure` now use `AnthropicClient(model=MODEL).analyze_sync(...)` and pull usage from `client.get_last_call()`.
- Removed the local `_PRICING` table and `_extract_usage` helper — pricing is handled centrally by `TokenTracker` using the SDK's `ResultMessage.total_cost_usd` when available.
- Added `_usage_from_last_call()` to adapt `TokenTracker.record_call`'s shape to what report callers expect (`{input_tokens, output_tokens, total_tokens, cost_usd}`).
- `import anthropic` removed.

## Why independent of other steps

These two sites are single-turn prompts — no rate-limit handling, no tool-dispatch loop. They don't need the `sdk_errors` taxonomy (Step 1) or the `_run_query` error wiring (Step 2) to work. Safe to merge any time.

## Test plan

- [x] `from report import generator` imports cleanly.
- [x] `grep anthropic report/generator.py` returns nothing.
- [ ] Manual smoke test needs API key: `openant report --format html` against a completed scan. Deferred to Step 8 (end-to-end verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)