### PR TITLE
feat: surface SDK API errors as typed sdk_errors exceptions

### DIFF
--- a/libs/openant-core/tests/test_sdk_error_surfacing.py
+++ b/libs/openant-core/tests/test_sdk_error_surfacing.py
@@ -1,0 +1,148 @@
+"""Tests for AssistantMessage.error -> sdk_errors mapping in _run_query.
+
+The hot path (_run_query) requires an actual ClaudeSDKClient subprocess, so we
+can't unit-test it end-to-end without live API access. What we CAN test is the
+error-classification and rate-limiter-notification logic in isolation: mock out
+the message stream and assert the right exception propagates and the right
+rate-limiter call fires.
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Each test gets a clean rate-limiter singleton."""
+    from utilities import rate_limiter
+    rate_limiter._instance = None
+    yield
+    rate_limiter._instance = None
+
+
+def _assistant_msg(error=None, text=None):
+    """Build a real AssistantMessage — isinstance checks in _run_query need the real class."""
+    content = [TextBlock(text=text)] if text else []
+    return AssistantMessage(content=content, model="test-model", error=error)
+
+
+def _result_msg(cost=0.0):
+    return ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="test",
+        total_cost_usd=cost,
+        usage={},
+    )
+
+
+class _FakeClient:
+    """Drop-in stand-in for ClaudeSDKClient async context manager."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def query(self, prompt):
+        return None
+
+    async def receive_response(self):
+        for msg in self._messages:
+            yield msg
+
+
+def _run(messages):
+    """Invoke _run_query with a scripted message sequence. Returns (result, text) or raises."""
+    from utilities.llm_client import _run_query
+
+    options = MagicMock()
+    options.model = "test-model"
+    options.max_turns = 1
+
+    # _run_query imports ClaudeSDKClient from claude_agent_sdk on each call;
+    # patching the source module swaps it in place.
+    with patch("claude_agent_sdk.ClaudeSDKClient", lambda options: _FakeClient(messages)):
+        return asyncio.run(_run_query("prompt", options))
+
+
+class TestAssistantMessageErrorMapping:
+    def test_rate_limit_raises_rate_limit_error(self):
+        from utilities.sdk_errors import RateLimitError
+        msgs = [_assistant_msg(error="rate_limit", text="too many")]
+        with pytest.raises(RateLimitError):
+            _run(msgs)
+
+    def test_rate_limit_notifies_global_limiter(self):
+        from utilities.sdk_errors import RateLimitError
+        from utilities.rate_limiter import get_rate_limiter
+
+        limiter = get_rate_limiter()
+        limiter.report_rate_limit = MagicMock()
+
+        msgs = [_assistant_msg(error="rate_limit", text="slow down")]
+        with pytest.raises(RateLimitError):
+            _run(msgs)
+
+        limiter.report_rate_limit.assert_called_once_with(0)
+
+    def test_auth_error(self):
+        from utilities.sdk_errors import AuthError
+        msgs = [_assistant_msg(error="authentication_failed", text="bad key")]
+        with pytest.raises(AuthError):
+            _run(msgs)
+
+    def test_billing_error(self):
+        from utilities.sdk_errors import BillingError
+        msgs = [_assistant_msg(error="billing_error")]
+        with pytest.raises(BillingError):
+            _run(msgs)
+
+    def test_server_error(self):
+        from utilities.sdk_errors import ServerError
+        msgs = [_assistant_msg(error="server_error")]
+        with pytest.raises(ServerError):
+            _run(msgs)
+
+    def test_invalid_request(self):
+        from utilities.sdk_errors import InvalidRequestError
+        msgs = [_assistant_msg(error="invalid_request")]
+        with pytest.raises(InvalidRequestError):
+            _run(msgs)
+
+    def test_unknown_error_falls_back(self):
+        from utilities.sdk_errors import UnknownLLMError
+        msgs = [_assistant_msg(error="unknown")]
+        with pytest.raises(UnknownLLMError):
+            _run(msgs)
+
+    def test_non_rate_limit_does_not_notify_limiter(self):
+        from utilities.sdk_errors import AuthError
+        from utilities.rate_limiter import get_rate_limiter
+
+        limiter = get_rate_limiter()
+        limiter.report_rate_limit = MagicMock()
+
+        msgs = [_assistant_msg(error="authentication_failed")]
+        with pytest.raises(AuthError):
+            _run(msgs)
+
+        limiter.report_rate_limit.assert_not_called()
+
+    def test_clean_message_does_not_raise(self):
+        msgs = [
+            _assistant_msg(error=None, text="hello world"),
+            _result_msg(cost=0.001),
+        ]
+        result_msg, text = _run(msgs)
+        assert text == "hello world"
+        assert result_msg is not None

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -91,6 +91,10 @@ async def _run_query(prompt, options, label=""):
     Uses the async context manager approach (NOT the query() generator)
     to avoid anyio cancel-scope errors.
 
+    If the SDK reports an API error via AssistantMessage.error, this raises
+    the corresponding openant.utilities.sdk_errors exception class. Rate
+    limits additionally notify the GlobalRateLimiter so all workers back off.
+
     Args:
         prompt: The prompt text to send.
         options: ClaudeAgentOptions instance.
@@ -98,9 +102,16 @@ async def _run_query(prompt, options, label=""):
 
     Returns:
         Tuple of (ResultMessage, last_assistant_text).
+
+    Raises:
+        utilities.sdk_errors.OpenAntLLMError: subclass matching the SDK's
+            reported AssistantMessageError (RateLimitError, AuthError,
+            BillingError, InvalidRequestError, ServerError, UnknownLLMError).
     """
     import time
     from claude_agent_sdk import ClaudeSDKClient, AssistantMessage, ResultMessage
+
+    from .sdk_errors import error_from_kind, RateLimitError
 
     _verbose = os.getenv("OPENANT_VERBOSE", "").lower() == "true"
     tag = f"[SDK:{label}]" if label else "[SDK]"
@@ -127,6 +138,22 @@ async def _run_query(prompt, options, label=""):
         turn_count = 0
         async for message in client.receive_response():
             if isinstance(message, AssistantMessage):
+                # SDK signals API-level errors on AssistantMessage.error.
+                # Raise the typed openant exception; rate-limit errors also
+                # notify the global limiter so all threads back off.
+                msg_error = getattr(message, "error", None)
+                if msg_error:
+                    text_for_context = ""
+                    for block in getattr(message, "content", []):
+                        if type(block).__name__ == "TextBlock":
+                            text_for_context = block.text
+                            break
+                    exc = error_from_kind(msg_error, text_for_context)
+                    if isinstance(exc, RateLimitError):
+                        # No retry-after from SDK; default backoff applies.
+                        get_rate_limiter().report_rate_limit(0)
+                    raise exc
+
                 turn_count += 1
                 parts = []
                 tool_names = []


### PR DESCRIPTION
## Summary

Wires `AssistantMessage.error` detection into `_run_query` in `utilities/llm_client.py`. Every API-level error from the SDK now propagates as a typed `utilities.sdk_errors` exception. Rate-limit errors additionally notify the `GlobalRateLimiter` so concurrent workers back off.

## Why

The Claude Agent SDK surfaces API errors through `AssistantMessage.error: AssistantMessageError | None` (a Literal of `authentication_failed`, `billing_error`, `rate_limit`, `invalid_request`, `server_error`, `unknown`). Before this PR, `_run_query` ignored the field — errors never reached callers as exceptions. The four downstream ports (Steps 3/4/5a in `SDK_MIGRATION_COMPLETION_PLAN.md`) need this before they can swap `except anthropic.RateLimitError` for `except utilities.sdk_errors.RateLimitError`.

## Changes

- `_run_query` now inspects `message.error` on every `AssistantMessage`; raises the matching `sdk_errors` subclass via `error_from_kind()`.
- `RateLimitError` path calls `get_rate_limiter().report_rate_limit(0)`. The SDK doesn't surface `retry-after`, so the limiter's default 30s backoff applies.
- `tests/test_sdk_error_surfacing.py` — 9 tests via a mocked `ClaudeSDKClient` and real `AssistantMessage`/`ResultMessage` dataclasses. Covers each `AssistantMessageError` literal, the rate-limit notification, the non-rate-limit-doesn't-notify case, and the clean-path no-error case.

## Depends on

PR #31 (sdk_errors taxonomy) — merged.

## Test plan

- [x] 9 unit tests all pass.
- [x] No changes to existing call sites; downstream catches are added in Steps 3/4/5a.
- [ ] Step 0a (spike) — force a real rate limit in live traffic to confirm `message.error == "rate_limit"` actually fires before the `ResultMessage`. Not blocking this merge — if the SDK surfaces rate limits differently in practice, `_run_query` can gain a supplementary check without breaking callers. Deferred to user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)