### PR TITLE
refactor: port agentic_enhancer to Claude Agent SDK native tools

### DIFF
--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -1,8 +1,10 @@
 """
 Agentic Context Enhancer
 
-Main agent loop that iteratively explores the codebase to gather context.
-Uses Claude Sonnet with tool use to search and read code.
+Uses the Claude Agent SDK with native tools (Read, Grep, Glob, Bash) to
+explore the codebase and gather context for security analysis. Static
+dependencies are pre-resolved from the RepositoryIndex and included in
+the prompt so the model has a head start before exploring.
 
 Supports reachability-aware classification to distinguish:
 - EXPLOITABLE: Vulnerable + reachable from user input
@@ -12,14 +14,14 @@ Supports reachability-aware classification to distinguish:
 """
 
 import json
+import re
+import sys
 from typing import Optional, Set, List
 
-import anthropic
-
 from ..llm_client import TokenTracker, get_global_tracker
-from ..rate_limiter import get_rate_limiter
+from ..sdk_errors import RateLimitError
 from .repository_index import RepositoryIndex
-from .tools import TOOL_DEFINITIONS, ToolExecutor
+from .tools import ToolExecutor
 from .prompts import SYSTEM_PROMPT, get_user_prompt
 from .entry_point_detector import EntryPointDetector
 from .reachability_analyzer import ReachabilityAnalyzer
@@ -29,8 +31,46 @@ from .reachability_analyzer import ReachabilityAnalyzer
 AGENT_MODEL = "claude-sonnet-4-20250514"
 
 # Safety limits
-MAX_ITERATIONS = 20
-MAX_TOKENS_PER_RESPONSE = 4096
+MAX_TURNS = 20
+
+
+# JSON schema for structured agent output
+AGENT_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "include_functions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Function identifier in format 'relative/path.ext:functionName'",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Why this function is needed for context",
+                    },
+                },
+                "required": ["id", "reason"],
+            },
+        },
+        "usage_context": {"type": "string"},
+        "security_classification": {
+            "type": "string",
+            "enum": ["exploitable", "vulnerable_internal", "security_control", "neutral"],
+        },
+        "classification_reasoning": {"type": "string"},
+        "confidence": {"type": "number"},
+    },
+    "required": [
+        "include_functions",
+        "usage_context",
+        "security_classification",
+        "classification_reasoning",
+        "confidence",
+    ],
+}
 
 
 class AgentResult:
@@ -68,7 +108,7 @@ class AgentResult:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        result = {
+        return {
             "include_functions": self.include_functions,
             "usage_context": self.usage_context,
             "security_classification": self.security_classification,
@@ -84,16 +124,49 @@ class AgentResult:
             "reachability": {
                 "is_entry_point": self.is_entry_point,
                 "reachable_from_entry": self.reachable_from_entry,
-                "entry_point_path": self.entry_point_path
-            }
+                "entry_point_path": self.entry_point_path,
+            },
         }
-        return result
+
+
+def _pre_resolve_deps(tool_executor: ToolExecutor, static_deps: list, static_callers: list) -> str:
+    """Pre-resolve static dependencies via ToolExecutor and format for prompt."""
+    tool_executor.set_unit_context(static_deps, static_callers)
+    resolved = tool_executor.execute("get_static_dependencies", {})
+    parts = []
+    for label, key in [("Resolved Dependencies", "dependencies"), ("Resolved Callers", "callers")]:
+        items = resolved.get(key, {}).get("resolved", [])
+        if items:
+            parts.append(f"### {label} (from parsed index)")
+            for item in items[:15]:
+                if isinstance(item, dict):
+                    parts.append(f"- `{item.get('id', item.get('name', '?'))}` ({item.get('file', '')})")
+                else:
+                    parts.append(f"- `{item}`")
+    return "\n".join(parts) if parts else ""
+
+
+def _try_parse_json(text: str) -> Optional[dict]:
+    """Try to extract JSON from text, handling code blocks."""
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    match = re.search(r"```(?:json)?\s*\n(.*?)\n\s*```", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
 
 
 class ContextAgent:
     """
     Agent that explores codebase to gather context for security analysis.
-    Uses iterative tool use to trace call paths and understand code intent.
+    Uses Claude Agent SDK with native tools (Read, Grep, Glob, Bash) to
+    trace call paths and understand code intent. Static dependencies are
+    pre-resolved from the RepositoryIndex and included in the prompt.
 
     Supports reachability-aware classification when entry_points and
     reachability analyzer are provided.
@@ -106,7 +179,6 @@ class ContextAgent:
         verbose: bool = False,
         entry_points: Optional[Set[str]] = None,
         reachability: Optional[ReachabilityAnalyzer] = None,
-        client: Optional[anthropic.Anthropic] = None,
     ):
         """
         Initialize the agent.
@@ -117,8 +189,6 @@ class ContextAgent:
             verbose: If True, print debug information
             entry_points: Set of func_ids that are entry points (optional)
             reachability: ReachabilityAnalyzer for checking user input paths (optional)
-            client: Shared Anthropic client (reuse across workers to avoid FD exhaustion).
-                    If not provided, creates a new one (only for standalone/test use).
         """
         self.index = index
         self.tracker = tracker or get_global_tracker()
@@ -126,7 +196,6 @@ class ContextAgent:
         self.tool_executor = ToolExecutor(index)
         self.entry_points = entry_points or set()
         self.reachability = reachability
-        self.client = client or anthropic.Anthropic(max_retries=5)
 
     def analyze_unit(
         self,
@@ -134,10 +203,10 @@ class ContextAgent:
         unit_type: str,
         primary_code: str,
         static_deps: list[str],
-        static_callers: list[str]
+        static_callers: list[str],
     ) -> AgentResult:
         """
-        Analyze a code unit to gather context.
+        Analyze a code unit using Claude Agent SDK with native tools.
 
         Args:
             unit_id: Function identifier
@@ -149,6 +218,9 @@ class ContextAgent:
         Returns:
             AgentResult with gathered context
         """
+        # Lazy import to avoid breaking non-LLM commands at import time.
+        from ..llm_client import _run_query_sync, _build_options
+
         # Compute reachability info
         is_entry_point = unit_id in self.entry_points
         reachable_from_entry: Optional[bool] = None
@@ -161,7 +233,9 @@ class ContextAgent:
                 entry_point_path = self.reachability.get_entry_point_path(unit_id)
                 reaching_entry_point = self.reachability.get_reaching_entry_point(unit_id)
 
-        # Build initial prompt with reachability info
+        # Pre-resolve static deps from the index so the model has a head start
+        resolved_context = _pre_resolve_deps(self.tool_executor, static_deps, static_callers)
+
         user_prompt = get_user_prompt(
             unit_id=unit_id,
             unit_type=unit_type,
@@ -171,204 +245,123 @@ class ContextAgent:
             is_entry_point=is_entry_point,
             reachable_from_entry=reachable_from_entry,
             entry_point_path=entry_point_path,
-            reaching_entry_point=reaching_entry_point
+            reaching_entry_point=reaching_entry_point,
+        )
+        if resolved_context:
+            user_prompt += f"\n\n{resolved_context}"
+
+        repo_path = str(self.index.repo_path) if self.index.repo_path else None
+
+        options = _build_options(
+            model=AGENT_MODEL,
+            system=SYSTEM_PROMPT,
+            max_turns=MAX_TURNS,
+            allowed_tools=["Read", "Grep", "Glob", "Bash"],
+            add_dirs=[repo_path] if repo_path else [],
+            cwd=repo_path,
+            output_format={"type": "json_schema", "schema": AGENT_OUTPUT_SCHEMA},
+            max_budget_usd=0.50,
         )
 
-        # Initialize conversation
-        messages = [{"role": "user", "content": user_prompt}]
-
-        iterations = 0
-        total_input_tokens = 0
-        total_output_tokens = 0
-
-        while iterations < MAX_ITERATIONS:
-            iterations += 1
-
-            if self.verbose:
-                print(f"  Iteration {iterations}...")
-
-            # Call Claude with rate limiting
-            try:
-                # Wait if we're in a global backoff period
-                rate_limiter = get_rate_limiter()
-                rate_limiter.wait_if_needed()
-
-                response = self.client.messages.create(
-                    model=AGENT_MODEL,
-                    max_tokens=MAX_TOKENS_PER_RESPONSE,
-                    system=SYSTEM_PROMPT,
-                    tools=TOOL_DEFINITIONS,
-                    messages=messages
-                )
-            except anthropic.RateLimitError as exc:
-                # Report to global rate limiter so all workers back off
-                retry_after = float(exc.response.headers.get("retry-after", 0))
-                get_rate_limiter().report_rate_limit(retry_after)
-                # Attach agent state so the caller knows how far we got
-                exc.agent_state = {
-                    "iteration": iterations,
-                    "max_iterations": MAX_ITERATIONS,
-                    "tokens_used": total_input_tokens + total_output_tokens,
-                    "input_tokens": total_input_tokens,
-                    "output_tokens": total_output_tokens,
-                }
-                raise
-            except Exception as exc:
-                # Attach agent state so the caller knows how far we got
-                exc.agent_state = {
-                    "iteration": iterations,
-                    "max_iterations": MAX_ITERATIONS,
-                    "tokens_used": total_input_tokens + total_output_tokens,
-                    "input_tokens": total_input_tokens,
-                    "output_tokens": total_output_tokens,
-                }
-                raise
-
-            # Track tokens
-            total_input_tokens += response.usage.input_tokens
-            total_output_tokens += response.usage.output_tokens
-
-            # Process response
-            assistant_content = response.content
-            stop_reason = response.stop_reason
-
-            if self.verbose:
-                # Print text blocks
-                for block in assistant_content:
-                    if hasattr(block, 'text'):
-                        print(f"    Agent: {block.text[:200]}...")
-
-            # Check if we're done (finish tool called or no more tool use)
-            if stop_reason == "end_turn":
-                # Model finished without calling finish tool
-                # Return default result
-                if self.verbose:
-                    print("  Agent ended without calling finish tool")
-
-                return AgentResult(
-                    include_functions=[],
-                    usage_context="Agent did not complete analysis",
-                    security_classification="neutral",
-                    classification_reasoning="Analysis incomplete",
-                    confidence=0.3,
-                    iterations=iterations,
-                    total_tokens=total_input_tokens + total_output_tokens,
-                    is_entry_point=is_entry_point,
-                    reachable_from_entry=reachable_from_entry,
-                    entry_point_path=entry_point_path
-                )
-
-            # Process tool calls
-            tool_results = []
-            finish_result = None
-
-            for block in assistant_content:
-                if block.type == "tool_use":
-                    tool_name = block.name
-                    tool_input = block.input
-                    tool_use_id = block.id
-
-                    if self.verbose:
-                        print(f"    Tool: {tool_name}({json.dumps(tool_input)[:100]}...)")
-
-                    # Execute tool
-                    result = self.tool_executor.execute(tool_name, tool_input)
-
-                    if self.verbose:
-                        result_preview = str(result)[:200]
-                        print(f"    Result: {result_preview}...")
-
-                    # Check for finish
-                    if tool_name == "finish" and result.get("status") == "complete":
-                        finish_result = result.get("result", {})
-                        # Still add to tool_results for the message
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tool_use_id,
-                            "content": json.dumps(result)
-                        })
-                        break
-                    else:
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tool_use_id,
-                            "content": json.dumps(result)
-                        })
-
-            # If finish was called, return result
-            if finish_result:
-                # Record token usage
-                call_record = self.tracker.record_call(
-                    model=AGENT_MODEL,
-                    input_tokens=total_input_tokens,
-                    output_tokens=total_output_tokens
-                )
-
-                return AgentResult(
-                    include_functions=finish_result.get("include_functions", []),
-                    usage_context=finish_result.get("usage_context", ""),
-                    security_classification=finish_result.get("security_classification", "neutral"),
-                    classification_reasoning=finish_result.get("classification_reasoning", ""),
-                    confidence=finish_result.get("confidence", 0.5),
-                    iterations=iterations,
-                    total_tokens=total_input_tokens + total_output_tokens,
-                    is_entry_point=is_entry_point,
-                    reachable_from_entry=reachable_from_entry,
-                    entry_point_path=entry_point_path,
-                    input_tokens=total_input_tokens,
-                    output_tokens=total_output_tokens,
-                    cost_usd=call_record.get("cost_usd", 0.0),
-                )
-
-            # Add assistant message and tool results to conversation
-            messages.append({"role": "assistant", "content": assistant_content})
-
-            # Only add user message with tool results if there are results
-            # (empty content triggers API error: "user messages must have non-empty content")
-            if tool_results:
-                messages.append({"role": "user", "content": tool_results})
-            else:
-                # No tool calls but model didn't end — treat as incomplete
-                if self.verbose:
-                    print("  No tool calls in response, treating as incomplete")
-                return AgentResult(
-                    include_functions=[],
-                    usage_context="Agent response had no tool calls",
-                    security_classification="neutral",
-                    classification_reasoning="Analysis incomplete - no tool calls",
-                    confidence=0.3,
-                    iterations=iterations,
-                    total_tokens=total_input_tokens + total_output_tokens,
-                    is_entry_point=is_entry_point,
-                    reachable_from_entry=reachable_from_entry,
-                    entry_point_path=entry_point_path
-                )
-
-        # Max iterations reached
         if self.verbose:
-            print(f"  Max iterations ({MAX_ITERATIONS}) reached")
+            print(f"  Analyzing {unit_id} via SDK...", file=sys.stderr, flush=True)
 
-        # Record token usage
+        try:
+            result_message, last_text = _run_query_sync(user_prompt, options, label=unit_id)
+        except RateLimitError as exc:
+            # Rate limit is already reported to GlobalRateLimiter inside _run_query.
+            # Attach agent state so the caller (checkpoint/resume) knows how far we got.
+            exc.agent_state = {
+                "unit_id": unit_id,
+                "tokens_used": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+            raise
+        except Exception as exc:
+            # Attach agent state for non-rate-limit errors too (checkpoint telemetry).
+            exc.agent_state = {
+                "unit_id": unit_id,
+                "tokens_used": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+            raise
+
+        # Track usage via the SDK-reported totals
+        usage = (result_message.usage or {}) if result_message else {}
+        input_tokens = usage.get("input_tokens", 0)
+        output_tokens = usage.get("output_tokens", 0)
+        total_tokens = input_tokens + output_tokens
+        cost_usd_sdk = (result_message.total_cost_usd or 0.0) if result_message else None
+
         call_record = self.tracker.record_call(
             model=AGENT_MODEL,
-            input_tokens=total_input_tokens,
-            output_tokens=total_output_tokens
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd_sdk,
         )
+        call_cost = call_record.get("cost_usd", 0.0)
 
+        # Parse structured output (preferred) or fall back to text + JSON extraction
+        parsed: Optional[dict] = None
+        structured = getattr(result_message, "structured_output", None) if result_message else None
+        if structured and isinstance(structured, dict):
+            parsed = structured
+        if not parsed:
+            raw_text = (
+                result_message.result
+                if result_message and result_message.result
+                else last_text or ""
+            )
+            if raw_text:
+                parsed = _try_parse_json(raw_text)
+
+        # Num turns from SDK (for telemetry parity with the old iterations field)
+        num_turns = (
+            getattr(result_message, "num_turns", 0) if result_message else 0
+        ) or 0
+
+        if parsed and "security_classification" in parsed:
+            if self.verbose:
+                print(
+                    f"  Classification: {parsed['security_classification']} "
+                    f"(confidence: {parsed.get('confidence', '?')})",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            return AgentResult(
+                include_functions=parsed.get("include_functions", []),
+                usage_context=parsed.get("usage_context", ""),
+                security_classification=parsed.get("security_classification", "neutral"),
+                classification_reasoning=parsed.get("classification_reasoning", ""),
+                confidence=parsed.get("confidence", 0.5),
+                iterations=num_turns,
+                total_tokens=total_tokens,
+                is_entry_point=is_entry_point,
+                reachable_from_entry=reachable_from_entry,
+                entry_point_path=entry_point_path,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=call_cost,
+            )
+
+        if self.verbose:
+            print("  Could not parse agent response", file=sys.stderr, flush=True)
         return AgentResult(
             include_functions=[],
-            usage_context="Analysis terminated - max iterations reached",
+            usage_context="Could not parse agent response",
             security_classification="neutral",
-            classification_reasoning="Could not complete analysis within iteration limit",
+            classification_reasoning="Analysis response unparseable",
             confidence=0.2,
-            iterations=iterations,
-            total_tokens=total_input_tokens + total_output_tokens,
+            iterations=num_turns,
+            total_tokens=total_tokens,
             is_entry_point=is_entry_point,
             reachable_from_entry=reachable_from_entry,
             entry_point_path=entry_point_path,
-            input_tokens=total_input_tokens,
-            output_tokens=total_output_tokens,
-            cost_usd=call_record.get("cost_usd", 0.0),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=call_cost,
         )
 
 
@@ -379,22 +372,24 @@ def enhance_unit_with_agent(
     verbose: bool = False,
     entry_points: Optional[Set[str]] = None,
     reachability: Optional[ReachabilityAnalyzer] = None,
-    client: Optional[anthropic.Anthropic] = None,
 ) -> dict:
     """
     Enhance a single unit using the agentic approach.
 
+    Mutates ``unit`` in place: attaches ``agent_context`` and, if the agent
+    identified additional functions, extends ``unit["code"]["primary_code"]``
+    with those definitions.
+
     Args:
-        unit: Unit from dataset
+        unit: Unit from dataset (mutated in place)
         index: Repository index for searching
         tracker: Token tracker
         verbose: Print debug info
         entry_points: Set of func_ids that are entry points (optional)
         reachability: ReachabilityAnalyzer for checking user input paths (optional)
-        client: Shared Anthropic client (reuse across workers to avoid FD exhaustion).
 
     Returns:
-        Enhanced unit with agent_context field including reachability info
+        The same unit dict, with agent_context field including reachability info
     """
     agent = ContextAgent(
         index=index,
@@ -402,16 +397,23 @@ def enhance_unit_with_agent(
         verbose=verbose,
         entry_points=entry_points,
         reachability=reachability,
-        client=client,
     )
 
     # Extract unit info
     unit_id = unit.get("id", "unknown")
     unit_type = unit.get("unit_type", "function")
     code_section = unit.get("code", {})
-    primary_code = code_section.get("primary_code", "")
-    static_deps = unit.get("metadata", {}).get("direct_calls", [])
-    static_callers = unit.get("metadata", {}).get("direct_callers", [])
+    primary_code = (
+        code_section
+        if isinstance(code_section, str)
+        else code_section.get("primary_code", "")
+    )
+    metadata = unit.get("metadata", {})
+    if isinstance(metadata, str):
+        static_deps, static_callers = [], []
+    else:
+        static_deps = metadata.get("direct_calls", [])
+        static_callers = metadata.get("direct_callers", [])
 
     # Run agent
     result = agent.analyze_unit(
@@ -419,20 +421,33 @@ def enhance_unit_with_agent(
         unit_type=unit_type,
         primary_code=primary_code,
         static_deps=static_deps,
-        static_callers=static_callers
+        static_callers=static_callers,
     )
 
     # Add result to unit
     unit["agent_context"] = result.to_dict()
 
     # Assemble additional code if functions were identified
-    if result.include_functions:
+    if result.include_functions and isinstance(unit.get("code"), dict):
         additional_code = []
         additional_files = set()
 
         for func_info in result.include_functions:
-            func_id = func_info.get("id", "")
+            func_id = func_info if isinstance(func_info, str) else func_info.get("id", "")
             func_data = index.get_function(func_id)
+
+            # Fuzzy match: SDK native tools may return IDs that don't match the
+            # index exactly (e.g. "file.py:Class.method" vs index's "file.py:method").
+            if not func_data and func_id:
+                name_part = func_id.rsplit(":", 1)[-1] if ":" in func_id else func_id
+                if "." in name_part:
+                    name_part = name_part.rsplit(".", 1)[-1]
+                matches = index.search_by_name(name_part, exact=True)
+                if not matches:
+                    matches = index.search_by_name(name_part, exact=False)
+                if matches:
+                    func_data = matches[0]
+                    func_id = func_data.get("id", func_id)
 
             if func_data and func_data.get("code"):
                 additional_code.append(func_data["code"])
@@ -445,7 +460,7 @@ def enhance_unit_with_agent(
         # Append to primary_code with file boundaries
         if additional_code:
             FILE_BOUNDARY = "\n\n// ========== File Boundary ==========\n\n"
-            current_code = unit["code"]["primary_code"]
+            current_code = unit["code"].get("primary_code", "")
             assembled = current_code + FILE_BOUNDARY + FILE_BOUNDARY.join(additional_code)
             unit["code"]["primary_code"] = assembled
 
@@ -463,7 +478,7 @@ def enhance_unit_with_agent(
 def create_reachability_context(
     functions: dict,
     call_graph: dict,
-    reverse_call_graph: dict
+    reverse_call_graph: dict,
 ) -> tuple[Set[str], ReachabilityAnalyzer]:
     """
     Create entry points and reachability analyzer from call graph data.
@@ -502,7 +517,7 @@ def create_reachability_context(
     reachability = ReachabilityAnalyzer(
         functions=functions,
         reverse_call_graph=reverse_call_graph,
-        entry_points=entry_points
+        entry_points=entry_points,
     )
 
     return entry_points, reachability

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -565,13 +565,6 @@ class ContextEnhancer:
         stats = index.get_statistics()
         self._log("info", f"Indexed {stats['total_functions']} functions from {stats['total_files']} files")
 
-        # Create a single shared Anthropic client for all workers.
-        # Each ContextAgent previously created its own anthropic.Anthropic() instance,
-        # which spawns a new httpx connection pool. With 1000+ units and 8 workers,
-        # this exhausted file descriptors (macOS limit ~256). The httpx.Client
-        # underlying anthropic.Anthropic is thread-safe, so sharing is correct.
-        shared_client = anthropic.Anthropic(max_retries=5)
-
         # Filter to unprocessed units
         units_to_process = [(i, unit) for i, unit in enumerate(units) if unit.get("id") not in processed_ids]
 
@@ -581,7 +574,7 @@ class ContextEnhancer:
             unit_start = time.monotonic()
             classification = "neutral"
             try:
-                enhance_unit_with_agent(unit, index, self.tracker, verbose, client=shared_client)
+                enhance_unit_with_agent(unit, index, self.tracker, verbose)
 
                 agent_ctx = unit.get("agent_context", {})
                 classification = agent_ctx.get("security_classification", "neutral")


### PR DESCRIPTION
## Summary

Step 4 of the SDK migration (issue #35): port `utilities/agentic_enhancer/agent.py` from the `anthropic` SDK's manual tool-use loop to the Claude Agent SDK's native tools (Read, Grep, Glob, Bash) via `_run_query_sync`.

- Replaces the `while iterations < MAX_ITERATIONS: self.client.messages.create(...)` + `ToolExecutor` dispatch loop with a single `_run_query_sync` call that uses SDK-native tools against `index.repo_path`.
- Drops `self.client`, the `client` constructor param, and the `import anthropic`.
- Catches `utilities.sdk_errors.RateLimitError` instead of `anthropic.RateLimitError`. Global rate-limit notification already lives inside `llm_client._run_query` (PR #33), so callers only need to attach `agent_state` for checkpoint/resume telemetry before re-raising.
- Adds an `AGENT_OUTPUT_SCHEMA` for SDK structured output (mirrors PR #25).
- Pre-resolves static deps via `ToolExecutor.get_static_dependencies` and inlines them in the prompt so the model has a head start before exploring (mirrors PR #25).
- Preserves upstream PR #23's entry-point / reachability additions (`entry_points`, `reachability` constructor params and the `is_entry_point`, `reachable_from_entry`, `entry_point_path`, `reaching_entry_point` computations in `analyze_unit` feeding `get_user_prompt`).
- Preserves checkpoint-telemetry fields on `AgentResult`: `input_tokens`, `output_tokens`, `cost_usd` (current checkpoint code reads these from `agent_metadata`).

## Scope expansion: absorbed Step 5b (shared_client removal)

`context_enhancer.py` created `shared_client = anthropic.Anthropic(max_retries=5)` solely to pass to `enhance_unit_with_agent(..., client=shared_client)`. Now that the agent no longer accepts `client`, `shared_client` is dead on day one, so I removed it in the same PR rather than leaving an unused variable that would error on future review. `import anthropic` remains in `context_enhancer.py` because `_build_error_info` still calls `isinstance(exc, anthropic.APIConnectionError)` etc. — that's Step 5a and its own PR.

## Public API change

`ContextAgent.__init__` no longer accepts `client: Optional[anthropic.Anthropic]`. `enhance_unit_with_agent` also drops its `client=` kwarg. `test_resume_stage1.py`'s mock uses `**kwargs`, so it already tolerates the signature change. No external fork callers pass `client=` outside `context_enhancer.py`.

## Test plan

- [x] `python -c 'from utilities.agentic_enhancer.agent import ContextAgent'` imports cleanly against the project venv.
- [x] `pytest tests/test_enhancer_tools.py tests/test_resume_stage1.py tests/test_declared_dependencies.py tests/test_sdk_errors.py tests/test_sdk_error_surfacing.py -q` → 48 passed.
- [x] Full suite (excluding `test_go_cli.py` and `test_local_claude.py`) → 144 passed, 16 skipped.
- [x] `grep -n 'import anthropic\|anthropic\.' libs/openant-core/utilities/agentic_enhancer/agent.py` → zero matches.
- [ ] Manual smoke (not in CI): `openant enhance --fresh --workers 2` against a small repo with a real API key. Deferred to the Step 8 E2E wave per the migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)