### PR TITLE
refactor: port finding_verifier.py to Claude Agent SDK native tools

### DIFF
--- a/libs/openant-core/tests/test_local_claude.py
+++ b/libs/openant-core/tests/test_local_claude.py
@@ -288,50 +288,35 @@ class TestRunNativeVerification:
 # ---------------------------------------------------------------------------
 
 class TestVerifyWithNativeClaude:
-    """Tests for FindingVerifier.verify_result with mocked Anthropic client."""
+    """Tests for FindingVerifier.verify_result against the SDK-native path.
+
+    Mocks `utilities.finding_verifier.run_native_verification` (the wrapper
+    around the Claude Agent SDK) so we can exercise the parse/verdict paths
+    without spawning a real SDK subprocess.
+    """
 
     def _make_verifier(self, repo_path="/tmp/repo"):
         from utilities.finding_verifier import FindingVerifier
 
         index = MagicMock()
         index.repo_path = Path(repo_path) if repo_path else None
-        mock_client = MagicMock()
         tracker = TokenTracker()
-        verifier = FindingVerifier(index=index, tracker=tracker, client=mock_client)
-        return verifier, tracker, mock_client
+        verifier = FindingVerifier(index=index, tracker=tracker)
+        return verifier, tracker
 
-    def _mock_finish_response(self, verdict_dict, input_tokens=500, output_tokens=200):
-        """Create a mock Anthropic response that calls the 'finish' tool."""
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.name = "finish"
-        tool_block.input = verdict_dict
-        tool_block.id = "tool_001"
-
-        response = MagicMock()
-        response.content = [tool_block]
-        response.stop_reason = "tool_use"
-        response.usage = MagicMock(input_tokens=input_tokens, output_tokens=output_tokens)
-        return response
-
-    def _mock_text_response(self, text, input_tokens=500, output_tokens=200):
-        """Create a mock Anthropic response that ends with text (no tool call)."""
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = text
-
-        response = MagicMock()
-        response.content = [text_block]
-        response.stop_reason = "end_turn"
-        response.usage = MagicMock(input_tokens=input_tokens, output_tokens=output_tokens)
-        return response
-
-    def test_finish_tool_returns_verdict(self):
-        verifier, tracker, mock_client = self._make_verifier()
-        mock_client.messages.create.return_value = self._mock_finish_response(
-            {"agree": False, "correct_finding": "safe", "explanation": "Sanitized."},
-            input_tokens=5000, output_tokens=2000,
-        )
+    @patch("utilities.finding_verifier.run_native_verification")
+    def test_structured_json_returns_verdict(self, mock_run):
+        verifier, tracker = self._make_verifier()
+        mock_run.return_value = {
+            "text": json.dumps({
+                "agree": False,
+                "correct_finding": "safe",
+                "explanation": "Sanitized.",
+            }),
+            "input_tokens": 5000,
+            "output_tokens": 2000,
+            "cost_usd": 0.12,
+        }
 
         result = verifier.verify_result(
             code="function upload(req) { fs.writeFile(req.body.name, data); }",
@@ -342,17 +327,23 @@ class TestVerifyWithNativeClaude:
 
         assert result.correct_finding == "safe"
         assert result.agree is False
+        assert tracker.total_input_tokens == 5000
+        assert tracker.total_output_tokens == 2000
 
-    def test_text_response_with_json_parsed(self):
-        verifier, _, mock_client = self._make_verifier()
+    @patch("utilities.finding_verifier.run_native_verification")
+    def test_json_in_code_block_is_parsed(self, mock_run):
+        verifier, _tracker = self._make_verifier()
         verdict_json = json.dumps({
             "agree": False,
             "correct_finding": "protected",
             "explanation": "Auth check prevents exploitation.",
         })
-        mock_client.messages.create.return_value = self._mock_text_response(
-            f"Here's my analysis:\n\n```json\n{verdict_json}\n```"
-        )
+        mock_run.return_value = {
+            "text": f"Here's my analysis:\n\n```json\n{verdict_json}\n```",
+            "input_tokens": 500,
+            "output_tokens": 200,
+            "cost_usd": 0.01,
+        }
 
         result = verifier.verify_result(
             code="code", finding="vulnerable",
@@ -362,11 +353,33 @@ class TestVerifyWithNativeClaude:
         assert result.correct_finding == "protected"
         assert result.agree is False
 
-    def test_unparseable_text_returns_agree(self):
-        verifier, _, mock_client = self._make_verifier()
-        mock_client.messages.create.return_value = self._mock_text_response(
-            "not json at all"
+    @patch("utilities.finding_verifier.run_native_verification")
+    def test_freetext_verdict_fallback(self, mock_run):
+        verifier, _tracker = self._make_verifier()
+        mock_run.return_value = {
+            "text": "After tracing every input path the verdict is: **PROTECTED** "
+                    "because the middleware validates the token.",
+            "input_tokens": 200,
+            "output_tokens": 50,
+            "cost_usd": 0.005,
+        }
+
+        result = verifier.verify_result(
+            code="code", finding="vulnerable",
+            attack_vector="test", reasoning="test",
         )
+
+        assert result.correct_finding == "protected"
+
+    @patch("utilities.finding_verifier.run_native_verification")
+    def test_unparseable_text_returns_agree(self, mock_run):
+        verifier, _tracker = self._make_verifier()
+        mock_run.return_value = {
+            "text": "not json at all",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cost_usd": 0.0001,
+        }
 
         result = verifier.verify_result(
             code="code", finding="vulnerable",
@@ -376,33 +389,31 @@ class TestVerifyWithNativeClaude:
         assert result.agree is True
         assert result.correct_finding == "vulnerable"
 
-    def test_api_error_propagates(self):
-        import anthropic
-        verifier, _, mock_client = self._make_verifier()
-        mock_client.messages.create.side_effect = RuntimeError("API error")
+    @patch("utilities.finding_verifier.run_native_verification")
+    def test_sdk_failure_returns_conservative_agree(self, mock_run):
+        """Process-level SDK failures (CLI missing, subprocess died) are
+        absorbed into a conservative 'agree' verdict so the pipeline doesn't
+        abort on a single bad finding."""
+        verifier, _tracker = self._make_verifier()
+        mock_run.side_effect = RuntimeError("SDK subprocess died")
 
-        with pytest.raises(RuntimeError, match="API error"):
-            verifier.verify_result(
-                code="code", finding="bypassable",
-                attack_vector="test", reasoning="test",
-            )
+        result = verifier.verify_result(
+            code="code", finding="bypassable",
+            attack_vector="test", reasoning="test",
+        )
 
-    def test_max_iterations_returns_agree(self):
-        """When tool calls never finish, max iterations returns agree."""
-        verifier, _, mock_client = self._make_verifier()
-        # Return a tool_use response that's NOT 'finish' — forces continuation
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.name = "read_file"
-        tool_block.input = {"path": "test.py"}
-        tool_block.id = "tool_001"
+        assert result.agree is True
+        assert result.correct_finding == "bypassable"
+        assert "SDK subprocess died" in result.explanation
 
-        response = MagicMock()
-        response.content = [tool_block]
-        response.stop_reason = "tool_use"
-        response.usage = MagicMock(input_tokens=100, output_tokens=50)
+    def test_missing_repo_path_returns_agree(self):
+        """Without a repo path we can't drive the native SDK call — return a
+        conservative 'agree' verdict and log a warning."""
+        from utilities.finding_verifier import FindingVerifier
 
-        mock_client.messages.create.return_value = response
+        index = MagicMock()
+        index.repo_path = None
+        verifier = FindingVerifier(index=index, tracker=TokenTracker())
 
         result = verifier.verify_result(
             code="code", finding="vulnerable",
@@ -410,7 +421,8 @@ class TestVerifyWithNativeClaude:
         )
 
         assert result.agree is True
-        assert "Max iterations" in result.explanation
+        assert result.correct_finding == "vulnerable"
+        assert "repo_path" in result.explanation.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1,35 +1,28 @@
 """
-Stage 2 Finding Verifier (Enhanced)
+Stage 2 Finding Verifier (Enhanced, SDK-native)
 
-Stage 2 of the two-stage vulnerability analysis pipeline.
-Uses Opus with tool access to validate Stage 1 assessments by exploring
-the codebase - searching function usages, reading definitions, and
-tracing call paths.
+Stage 2 of the two-stage vulnerability analysis pipeline. Validates Stage 1
+assessments by letting Claude Code explore the codebase with its native
+Read/Grep/Glob/Bash tools to trace exploit paths from attacker input to sink.
 
-Key Improvements:
-    1. Explicit vulnerability definitions (exploitable NOW vs dangerous design)
-    2. Required exploit path tracing (entry point -> sink)
-    3. Consistency cross-check for similar code patterns
-    4. Structured output with exploit_path field
-    5. Batch verification with consistency validation
-
-The verifier asks: "Can an attacker exploit this NOW in the current codebase?"
-It validates by tracing the complete exploit path from attacker input to sink.
-
-Available Tools:
-    - search_usages: Find where a function is called
-    - search_definitions: Find where a function is defined
-    - read_function: Get full function code by ID
-    - list_functions: List all functions in a file
-    - finish: Complete verification with verdict and exploit path
+This module used to drive a manual tool-dispatch loop against the `anthropic`
+SDK (search_usages / search_definitions / read_function / list_functions /
+finish). That loop has been replaced with a single SDK-native call to
+`run_native_verification` from `utilities.llm_client`, which delegates to the
+Claude Agent SDK. Rate-limit handling is centralised in
+`utilities.llm_client._run_query` and surfaces via
+`utilities.sdk_errors.RateLimitError`.
 
 Classes:
-    VerificationResult: Dataclass containing verdict, exploit path, explanation
-    FindingVerifier: Main verifier class with verify_result() and verify_batch() methods
+    ExploitPath: Structured exploit path analysis.
+    VerificationResult: Dataclass containing verdict, exploit path, explanation.
+    ConsistencyCheckResult: Result from cross-pattern consistency check.
+    FindingVerifier: Main verifier class with verify_result() and verify_batch() methods.
 """
 
 import json
 import logging
+import os
 import re
 import sys
 import threading
@@ -38,21 +31,27 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
-import anthropic
-
-from .llm_client import TokenTracker, get_global_tracker
+from .llm_client import (
+    AnthropicClient,
+    TokenTracker,
+    get_global_tracker,
+    run_native_verification,
+)
 from .rate_limiter import get_rate_limiter
 
 # Null logger that discards all messages (used when no logger provided)
 _null_logger = logging.getLogger("null_verifier")
 _null_logger.addHandler(logging.NullHandler())
+
 from .agentic_enhancer.repository_index import RepositoryIndex
-from .agentic_enhancer.tools import ToolExecutor
+from .model_config import MODEL_PRIMARY
 from prompts.verification_prompts import (
+    VERIFICATION_JSON_SCHEMA,
     VERIFICATION_SYSTEM_PROMPT,
+    get_consistency_check_prompt,
+    get_native_claude_verification_prompt,
     get_verification_prompt,
     get_verification_system_prompt,
-    get_consistency_check_prompt
 )
 
 # Import application context type for type hints
@@ -62,125 +61,13 @@ except ImportError:
     ApplicationContext = None
 
 
-VERIFIER_MODEL = "claude-opus-4-6"
-MAX_ITERATIONS = 20
-MAX_TOKENS_PER_RESPONSE = 4096
-
-
-# Enhanced finish tool with exploit_path structure
-VERIFICATION_TOOLS = [
-    {
-        "name": "search_usages",
-        "description": "Search for all places where a function is called/used in the codebase. Use this to trace how attacker input flows through the code.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "function_name": {
-                    "type": "string",
-                    "description": "Name of the function to find usages of"
-                }
-            },
-            "required": ["function_name"]
-        }
-    },
-    {
-        "name": "search_definitions",
-        "description": "Search for where a function is defined. Use this to understand what a function does.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "function_name": {
-                    "type": "string",
-                    "description": "Name of the function to find definition of"
-                }
-            },
-            "required": ["function_name"]
-        }
-    },
-    {
-        "name": "read_function",
-        "description": "Read the full source code of a function by its ID. Use this to analyze function behavior.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "function_id": {
-                    "type": "string",
-                    "description": "Function identifier in format 'file/path.ts:functionName'"
-                }
-            },
-            "required": ["function_id"]
-        }
-    },
-    {
-        "name": "list_functions",
-        "description": "List all functions defined in a specific file.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "file_path": {
-                    "type": "string",
-                    "description": "Path to the file relative to repository root"
-                }
-            },
-            "required": ["file_path"]
-        }
-    },
-    {
-        "name": "finish",
-        "description": "Complete the verification with your verdict and exploit path analysis.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "agree": {
-                    "type": "boolean",
-                    "description": "Whether you agree with Stage 1's assessment"
-                },
-                "correct_finding": {
-                    "type": "string",
-                    "enum": ["safe", "protected", "bypassable", "vulnerable", "inconclusive"],
-                    "description": "The correct finding based on exploit path analysis"
-                },
-                "exploit_path": {
-                    "type": "object",
-                    "description": "Analysis of the exploit path from attacker input to sink",
-                    "properties": {
-                        "entry_point": {
-                            "type": ["string", "null"],
-                            "description": "Where attacker input enters (null if none found)"
-                        },
-                        "data_flow": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Steps showing how data flows from entry to sink"
-                        },
-                        "sink_reached": {
-                            "type": "boolean",
-                            "description": "Whether attacker-controlled data reaches the vulnerable operation"
-                        },
-                        "attacker_control_at_sink": {
-                            "type": "string",
-                            "enum": ["full", "partial", "none"],
-                            "description": "Level of attacker control at the dangerous operation"
-                        },
-                        "path_broken_at": {
-                            "type": ["string", "null"],
-                            "description": "Where/why the exploit path breaks (null if complete)"
-                        }
-                    }
-                },
-                "explanation": {
-                    "type": "string",
-                    "description": "Detailed explanation of your analysis"
-                },
-                "security_weakness": {
-                    "type": ["string", "null"],
-                    "description": "Any dangerous patterns that exist but aren't currently exploitable (optional)"
-                }
-            },
-            "required": ["agree", "correct_finding", "explanation"]
-        }
-    }
-]
+VERIFIER_MODEL = MODEL_PRIMARY
+# Budget ceiling per-finding for the native SDK verification call. The SDK
+# will halt multi-turn exploration if cumulative cost exceeds this.
+MAX_BUDGET_USD_PER_FINDING = 0.30
+# Hard timeout per-finding (seconds). Passed through for API compat; the
+# SDK's own message loop governs actual wall-clock behaviour.
+MAX_VERIFICATION_TIMEOUT_S = 600
 
 
 @dataclass
@@ -221,6 +108,7 @@ class VerificationResult:
     total_tokens: int
     exploit_path: Optional[ExploitPath] = None
     security_weakness: Optional[str] = None
+    raw_response: Optional[str] = None  # Full SDK response text (not serialized)
 
     def to_dict(self) -> dict:
         result = {
@@ -255,7 +143,7 @@ class ConsistencyCheckResult:
 
 
 class FindingVerifier:
-    """Validates Stage 1 assessments using Opus with tool access."""
+    """Validates Stage 1 assessments using Claude Code's native tools via the Agent SDK."""
 
     def __init__(
         self,
@@ -264,16 +152,24 @@ class FindingVerifier:
         verbose: bool = False,
         app_context: "ApplicationContext" = None,
         logger: logging.Logger = None,
-        client: "anthropic.Anthropic | None" = None,
+        output_dir: str = None,
     ):
         self.index = index
         self.tracker = tracker or get_global_tracker()
         self.verbose = verbose
         self.app_context = app_context
-        self.tool_executor = ToolExecutor(index)
-        self.client = client or anthropic.Anthropic(max_retries=5)
         self.logger = logger or _null_logger
         self._use_logger = logger is not None
+        self.output_dir = output_dir
+        # Single-turn client used for the consistency cross-check step
+        # (which does not need multi-turn native tool use).
+        self._consistency_client = AnthropicClient(
+            model=VERIFIER_MODEL, tracker=self.tracker,
+        )
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
 
     def _log(self, level: str, msg: str, **extras):
         """Log a message, using logger if available, otherwise print if verbose."""
@@ -281,9 +177,60 @@ class FindingVerifier:
             log_func = getattr(self.logger, level, self.logger.info)
             log_func(msg, extra=extras)
         elif self.verbose:
-            # Fallback to print for CLI usage
+            # Fallback to print for CLI usage (stderr to avoid corrupting JSON stdout)
             suffix = " ".join(f"{k}={v}" for k, v in extras.items() if v is not None)
-            print(f"    {msg} {suffix}" if suffix else f"    {msg}")
+            print(f"    {msg} {suffix}" if suffix else f"    {msg}",
+                  file=sys.stderr, flush=True)
+
+    def _save_explanation(self, route_key: str, verification: "VerificationResult"):
+        """Save verification explanation to a file in the output directory."""
+        if not self.output_dir:
+            return
+        verify_dir = os.path.join(self.output_dir, "verify_explanations")
+        try:
+            os.makedirs(verify_dir, exist_ok=True)
+        except OSError as e:
+            print(f"[Verify] Could not create explanation dir for {route_key}: {e}",
+                  file=sys.stderr, flush=True)
+            return
+
+        # Sanitize route_key for use as filename
+        safe_name = re.sub(r'[\\/:*?"<>|]', '_', route_key)
+        filepath = os.path.join(verify_dir, f"{safe_name}.md")
+
+        lines = [f"# {route_key}\n"]
+        lines.append(f"**Verdict:** {verification.correct_finding}")
+        lines.append(f"**Agrees with Stage 1:** {verification.agree}\n")
+        if verification.exploit_path:
+            ep = verification.exploit_path
+            lines.append("## Exploit Path\n")
+            if ep.entry_point:
+                lines.append(f"**Entry point:** {ep.entry_point}\n")
+            if ep.data_flow:
+                lines.append("**Data flow:**")
+                for step in ep.data_flow:
+                    lines.append(f"1. {step}")
+                lines.append("")
+            lines.append(f"**Sink reached:** {ep.sink_reached}")
+            lines.append(f"**Attacker control at sink:** {ep.attacker_control_at_sink}")
+            if ep.path_broken_at:
+                lines.append(f"**Path broken at:** {ep.path_broken_at}")
+            lines.append("")
+        lines.append("## Explanation\n")
+        lines.append(verification.explanation)
+        if verification.security_weakness:
+            lines.append(f"\n## Security Weakness\n\n{verification.security_weakness}")
+
+        try:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        except OSError as e:
+            print(f"[Verify] Could not save explanation for {route_key}: {e}",
+                  file=sys.stderr, flush=True)
+
+    # ------------------------------------------------------------------
+    # Single-finding verification (native SDK call)
+    # ------------------------------------------------------------------
 
     def verify_result(
         self,
@@ -296,135 +243,114 @@ class FindingVerifier:
         """
         Validate a Stage 1 assessment with exploit path tracing.
 
+        Delegates to the Claude Agent SDK with native tools (Read, Grep,
+        Glob, Bash). Rate-limit handling is centralised in
+        `utilities.llm_client._run_query`.
+
         Args:
-            code: The code that was assessed
-            finding: Stage 1's finding
-            attack_vector: Stage 1's attack vector
-            reasoning: Stage 1's reasoning
-            files_included: Optional list of files in context
+            code: The code that was assessed.
+            finding: Stage 1's finding.
+            attack_vector: Stage 1's attack vector.
+            reasoning: Stage 1's reasoning.
+            files_included: Optional list of files in context.
 
         Returns:
-            VerificationResult with verdict, exploit path, and explanation
+            VerificationResult with verdict, exploit path, and explanation.
         """
-        user_prompt = get_verification_prompt(
+        repo_path = str(self.index.repo_path) if getattr(self.index, "repo_path", None) else None
+        if not repo_path:
+            self._log("warning", "No repo_path available for native SDK verification")
+            return VerificationResult(
+                agree=True,
+                correct_finding=finding,
+                explanation="No repo_path available for native SDK verification",
+                iterations=0,
+                total_tokens=0,
+            )
+
+        user_prompt = get_native_claude_verification_prompt(
             code=code,
             finding=finding,
             attack_vector=attack_vector,
             reasoning=reasoning,
             files_included=files_included,
-            app_context=self.app_context
+            app_context=self.app_context,
         )
-
-        # Get system prompt with app context if available
         system_prompt = get_verification_system_prompt(self.app_context)
 
-        messages = [{"role": "user", "content": user_prompt}]
-        iterations = 0
-        total_input_tokens = 0
-        total_output_tokens = 0
+        # Respect the global rate limiter. _run_query_sync will also raise
+        # utilities.sdk_errors.RateLimitError (and notify the limiter) if the
+        # SDK reports a rate-limit mid-flight.
+        get_rate_limiter().wait_if_needed()
 
-        while iterations < MAX_ITERATIONS:
-            iterations += 1
+        try:
+            result = run_native_verification(
+                prompt=user_prompt,
+                system=system_prompt,
+                model=VERIFIER_MODEL,
+                repo_path=repo_path,
+                json_schema=VERIFICATION_JSON_SCHEMA,
+                max_budget_usd=MAX_BUDGET_USD_PER_FINDING,
+                timeout=MAX_VERIFICATION_TIMEOUT_S,
+            )
+        except (RuntimeError, FileNotFoundError, TimeoutError) as exc:
+            # Process-level failures (SDK subprocess died, CLI missing, etc.)
+            # fall through to a conservative "agree" verdict so the pipeline
+            # does not abort on a single bad finding. Rate-limit errors are
+            # re-raised unmodified so the caller's backoff/retry logic can
+            # see them.
+            print(f"[Verify] Native SDK verification failed: {exc}",
+                  file=sys.stderr, flush=True)
+            return VerificationResult(
+                agree=True,
+                correct_finding=finding,
+                explanation=f"Verification failed: {exc}",
+                iterations=0,
+                total_tokens=0,
+            )
 
-            self._log("debug", f"Iteration {iterations}", iterations=iterations)
-
-            # Wait if we're in a global backoff period
-            rate_limiter = get_rate_limiter()
-            rate_limiter.wait_if_needed()
-
-            try:
-                response = self.client.messages.create(
-                    model=VERIFIER_MODEL,
-                    max_tokens=MAX_TOKENS_PER_RESPONSE,
-                    system=system_prompt,
-                    tools=VERIFICATION_TOOLS,
-                    messages=messages
-                )
-            except anthropic.RateLimitError as exc:
-                # Report to global rate limiter so all workers back off
-                retry_after = float(exc.response.headers.get("retry-after", 0))
-                get_rate_limiter().report_rate_limit(retry_after)
-                raise
-
-            total_input_tokens += response.usage.input_tokens
-            total_output_tokens += response.usage.output_tokens
-
-            assistant_content = response.content
-            stop_reason = response.stop_reason
-
-            # If model finished without calling finish tool, try to parse response
-            if stop_reason == "end_turn":
-                result = self._try_parse_text_response(
-                    assistant_content, finding, iterations,
-                    total_input_tokens, total_output_tokens
-                )
-                if result:
-                    return result
-
-                # Default: agree with Stage 1
-                return VerificationResult(
-                    agree=True,
-                    correct_finding=finding,
-                    explanation="Verification incomplete",
-                    iterations=iterations,
-                    total_tokens=total_input_tokens + total_output_tokens
-                )
-
-            # Process tool calls
-            tool_results = []
-            finish_result = None
-
-            for block in assistant_content:
-                if block.type == "tool_use":
-                    tool_name = block.name
-                    tool_input = block.input
-                    tool_use_id = block.id
-
-                    self._log("debug", f"Tool call: {tool_name}")
-
-                    if tool_name == "finish":
-                        finish_result = tool_input
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tool_use_id,
-                            "content": json.dumps({"status": "complete"})
-                        })
-                        break
-                    else:
-                        result = self.tool_executor.execute(tool_name, tool_input)
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tool_use_id,
-                            "content": json.dumps(result)
-                        })
-
-            if finish_result:
-                self.tracker.record_call(
-                    model=VERIFIER_MODEL,
-                    input_tokens=total_input_tokens,
-                    output_tokens=total_output_tokens
-                )
-                return self._parse_finish_result(
-                    finish_result, finding, iterations,
-                    total_input_tokens + total_output_tokens
-                )
-
-            messages.append({"role": "assistant", "content": assistant_content})
-            messages.append({"role": "user", "content": tool_results})
-
-        # Max iterations reached
+        input_tokens = result.get("input_tokens", 0)
+        output_tokens = result.get("output_tokens", 0)
+        total_tokens = input_tokens + output_tokens
         self.tracker.record_call(
             model=VERIFIER_MODEL,
-            input_tokens=total_input_tokens,
-            output_tokens=total_output_tokens
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=result.get("cost_usd"),
         )
+
+        raw_text = result.get("text", "") or ""
+
+        # Preferred path: structured JSON (either from SDK structured_output
+        # or embedded in the message text).
+        parsed = self._extract_json(raw_text)
+        if parsed and "correct_finding" in parsed:
+            vr = self._parse_finish_result(parsed, finding, 0, total_tokens)
+            vr.raw_response = raw_text
+            return vr
+
+        # Fallback: try to extract a verdict from free-form text.
+        fallback = self._parse_freetext_verdict(raw_text, finding)
+        if fallback:
+            vr = self._parse_finish_result(fallback, finding, 0, total_tokens)
+            vr.raw_response = raw_text
+            return vr
+
+        # Final fallback: conservative agree.
+        print(f"[Verify] Could not parse SDK response: {raw_text[:500]}",
+              file=sys.stderr, flush=True)
         return VerificationResult(
             agree=True,
             correct_finding=finding,
-            explanation="Max iterations reached",
-            iterations=iterations,
-            total_tokens=total_input_tokens + total_output_tokens
+            explanation="Could not parse verification response",
+            iterations=0,
+            total_tokens=total_tokens,
+            raw_response=raw_text,
         )
+
+    # ------------------------------------------------------------------
+    # Batch verification (parallel, checkpoint-aware) — upstream API
+    # ------------------------------------------------------------------
 
     def verify_batch(
         self,
@@ -442,8 +368,8 @@ class FindingVerifier:
         Supports checkpoint/resume via the checkpoint parameter.
 
         Args:
-            results: List of Stage 1 results to verify
-            code_by_route: Dict mapping route_key to code
+            results: List of Stage 1 results to verify.
+            code_by_route: Dict mapping route_key to code.
             progress_callback: Optional callback(unit_id, detail, unit_elapsed)
                 called after each finding is verified.
             workers: Number of parallel workers (default: 10).
@@ -452,7 +378,7 @@ class FindingVerifier:
                 loading with the number of restored units.
 
         Returns:
-            Updated results with verification and consistency check
+            Updated results with verification and consistency check.
         """
         total = len(results)
 
@@ -611,9 +537,14 @@ class FindingVerifier:
                           unit_id=route_key, total_tokens=verification.total_tokens,
                           iterations=verification.iterations)
 
+            # Optionally save explanation to disk (for run-level debugging)
+            if self.output_dir and verification.explanation:
+                self._save_explanation(route_key, verification)
+
         except Exception as e:
             detail = "error"
-            print(f"[Verify] ERROR {route_key}: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+            print(f"[Verify] ERROR {route_key}: {type(e).__name__}: {e}",
+                  file=sys.stderr, flush=True)
 
         unit_elapsed = time.monotonic() - unit_start
         usage = self.tracker.get_unit_usage()
@@ -683,6 +614,10 @@ class FindingVerifier:
                   file=sys.stderr, flush=True)
             return
         executor.shutdown(wait=False)
+
+    # ------------------------------------------------------------------
+    # Consistency cross-check
+    # ------------------------------------------------------------------
 
     def _check_consistency(
         self,
@@ -763,9 +698,6 @@ class FindingVerifier:
            - sink_reached = false (attacker data doesn't reach the sink)
            - attacker_control_at_sink = "none" (no control at sink)
            - path_broken_at is set (explicit explanation of where path breaks)
-
-        These findings are based on detailed code analysis and should not be
-        overridden by superficial pattern matching.
         """
         verification = result.get("verification", {})
 
@@ -825,49 +757,43 @@ class FindingVerifier:
         code_by_route: dict
     ) -> Optional[ConsistencyCheckResult]:
         """
-        Use LLM to resolve inconsistent verdicts for similar code patterns.
+        Use a single-turn LLM call to resolve inconsistent verdicts for
+        similar code patterns.
+
+        Rate-limit handling: `_run_query` inside `AnthropicClient.analyze_sync`
+        raises `utilities.sdk_errors.RateLimitError` and notifies the global
+        rate limiter automatically. We don't need to catch it here — callers
+        higher up retry as appropriate.
         """
         prompt = get_consistency_check_prompt(group, code_by_route)
 
+        # Respect the global rate limiter before dispatching.
+        get_rate_limiter().wait_if_needed()
+
         try:
-            # Wait if we're in a global backoff period
-            rate_limiter = get_rate_limiter()
-            rate_limiter.wait_if_needed()
-
-            response = self.client.messages.create(
-                model=VERIFIER_MODEL,
-                max_tokens=MAX_TOKENS_PER_RESPONSE,
+            text = self._consistency_client.analyze_sync(
+                prompt,
                 system="You are checking verdict consistency across similar code patterns.",
-                messages=[{"role": "user", "content": prompt}]
             )
-
-            self.tracker.record_call(
-                model=VERIFIER_MODEL,
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens
-            )
-
-            # Parse response
-            text = response.content[0].text if response.content else ""
-            result = self._parse_json_from_text(text)
-
-            if result:
-                return ConsistencyCheckResult(
-                    pattern_identified=result.get("pattern_identified", "unknown"),
-                    consistent_verdict=result.get("consistent_verdict", "inconclusive"),
-                    findings_updated=result.get("findings_to_update", []),
-                    explanation=result.get("explanation", "")
-                )
-
-        except anthropic.RateLimitError as e:
-            # Report to global rate limiter so all workers back off
-            retry_after = float(e.response.headers.get("retry-after", 0))
-            get_rate_limiter().report_rate_limit(retry_after)
-            self._log("error", f"Consistency resolution rate limited", error=str(e))
         except Exception as e:
+            # Non-rate-limit failure — log and leave the group unresolved.
             self._log("error", f"Consistency resolution failed", error=str(e))
+            return None
 
-        return None
+        result = self._parse_json_from_text(text)
+        if not result:
+            return None
+
+        return ConsistencyCheckResult(
+            pattern_identified=result.get("pattern_identified", "unknown"),
+            consistent_verdict=result.get("consistent_verdict", "inconclusive"),
+            findings_updated=result.get("findings_to_update", []),
+            explanation=result.get("explanation", ""),
+        )
+
+    # ------------------------------------------------------------------
+    # Result / response parsing
+    # ------------------------------------------------------------------
 
     def _parse_finish_result(
         self,
@@ -876,8 +802,7 @@ class FindingVerifier:
         iterations: int,
         total_tokens: int
     ) -> VerificationResult:
-        """Parse the finish tool result into VerificationResult."""
-        # Parse exploit path if present
+        """Parse the finish-tool-style dict (or structured JSON) into VerificationResult."""
         exploit_path = None
         if "exploit_path" in finish_result and finish_result["exploit_path"]:
             ep = finish_result["exploit_path"]
@@ -899,32 +824,8 @@ class FindingVerifier:
             security_weakness=finish_result.get("security_weakness")
         )
 
-    def _try_parse_text_response(
-        self,
-        assistant_content: list,
-        original_finding: str,
-        iterations: int,
-        total_input_tokens: int,
-        total_output_tokens: int
-    ) -> Optional[VerificationResult]:
-        """Try to parse a text response as JSON."""
-        for block in assistant_content:
-            if hasattr(block, 'text'):
-                result = self._parse_json_from_text(block.text)
-                if result:
-                    self.tracker.record_call(
-                        model=VERIFIER_MODEL,
-                        input_tokens=total_input_tokens,
-                        output_tokens=total_output_tokens
-                    )
-                    return self._parse_finish_result(
-                        result, original_finding, iterations,
-                        total_input_tokens + total_output_tokens
-                    )
-        return None
-
     def _parse_json_from_text(self, text: str) -> Optional[dict]:
-        """Extract JSON object from text, with LLM correction fallback."""
+        """Extract a JSON object from text, with LLM correction fallback."""
         try:
             start = text.find('{')
             end = text.rfind('}') + 1
@@ -937,7 +838,7 @@ class FindingVerifier:
         if text.strip():
             try:
                 from utilities.json_corrector import JSONCorrector
-                corrector = JSONCorrector(self.client)
+                corrector = JSONCorrector(self._consistency_client)
                 corrected = corrector.attempt_correction(text)
                 if corrected.get("verdict") != "ERROR":
                     corrected["json_corrected"] = True
@@ -945,3 +846,89 @@ class FindingVerifier:
             except Exception:
                 pass
         return None
+
+    @staticmethod
+    def _extract_json(text: str) -> Optional[dict]:
+        """Extract a JSON object from text without LLM fallback.
+
+        Tries:
+        1. Parse the entire text as JSON
+        2. Extract JSON from a ```json code block
+        3. Find the outermost { ... } pair
+        """
+        if not text:
+            return None
+        text = text.strip()
+
+        # Try parsing the whole thing
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+        # Try extracting from ```json ... ``` code block
+        json_block = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', text, re.DOTALL)
+        if json_block:
+            try:
+                return json.loads(json_block.group(1))
+            except json.JSONDecodeError:
+                pass
+
+        # Try finding outermost braces
+        start = text.find('{')
+        end = text.rfind('}') + 1
+        if start >= 0 and end > start:
+            try:
+                return json.loads(text[start:end])
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
+    @staticmethod
+    def _parse_freetext_verdict(text: str, original_finding: str) -> Optional[dict]:
+        """Extract a verdict from free-text response when JSON parsing fails.
+
+        Looks for keywords like PROTECTED, SAFE, VULNERABLE in the response
+        and constructs a result dict.
+        """
+        if not text:
+            return None
+        text_lower = text.lower()
+
+        # Determine verdict from common patterns
+        correct_finding = None
+        agree = None
+
+        if "disagree" in text_lower:
+            agree = False
+        elif "agree" in text_lower:
+            agree = True
+
+        for verdict in ["vulnerable", "bypassable", "protected", "safe", "inconclusive"]:
+            patterns = [
+                rf'(?:verdict|finding|correct_finding|conclusion)[:\s]*\**{verdict}\**',
+                rf'\*\*{verdict.upper()}\*\*',
+            ]
+            for pattern in patterns:
+                if re.search(pattern, text, re.IGNORECASE):
+                    correct_finding = verdict
+                    break
+            if correct_finding:
+                break
+
+        if not correct_finding:
+            return None
+
+        if agree is None:
+            agree = correct_finding == original_finding
+
+        explanation = text[:500].strip()
+        if len(text) > 500:
+            explanation += "..."
+
+        return {
+            "agree": agree,
+            "correct_finding": correct_finding,
+            "explanation": explanation,
+        }


### PR DESCRIPTION
## Summary

Ports `utilities/finding_verifier.py` from the `anthropic` SDK to the Claude Agent SDK. This is Step 3 of the SDK migration tracked in issue #35.

The manual tool-dispatch loop (`search_usages`, `search_definitions`, `read_function`, `list_functions`, `finish`) is replaced with a single call to `utilities.llm_client.run_native_verification`, which runs a multi-turn SDK session with native `Read`/`Grep`/`Glob`/`Bash` tools and returns structured JSON via `VERIFICATION_JSON_SCHEMA`. Rate-limit handling is now centralised in `utilities.llm_client._run_query` (via `sdk_errors.RateLimitError` and `GlobalRateLimiter`), so the old `except anthropic.RateLimitError` blocks are gone.

This reapplies PR #25's Step 3 work, adapted for the current post-merge state (upstream PR #23 re-introduced the `anthropic` path and added `logger`/`app_context`/`verbose`/checkpoint/workers APIs that must be preserved).

## Key changes

**`libs/openant-core/utilities/finding_verifier.py`**
- Drop `client: anthropic.Anthropic | None` constructor param and the whole `while iterations < MAX_ITERATIONS: self.client.messages.create(tools=VERIFICATION_TOOLS, ...)` loop.
- Drop imports of `anthropic`, `ToolExecutor`, and the `VERIFICATION_TOOLS` schema.
- `verify_result` now calls `run_native_verification` with the SDK-aware `get_native_claude_verification_prompt` and `VERIFICATION_JSON_SCHEMA`. Process-level SDK failures return a conservative "agree" verdict; rate-limit errors surface as `sdk_errors.RateLimitError` and are handled by the centralised wrapper.
- Consistency cross-check (`_resolve_inconsistency`) uses a dedicated `AnthropicClient` single-turn call instead of raw `client.messages.create`.
- Add `output_dir` constructor param + `_save_explanation` helper (already expected by `core/verifier.py`).
- `VERIFIER_MODEL` now pulls from `utilities.model_config.MODEL_PRIMARY`.
- **Preserve upstream PR #23 APIs**: `verify_batch(..., workers=10, checkpoint=None, restored_callback=None)`, `_verify_batch_sequential/_parallel`, `_verify_one`, `_check_consistency`, `_has_conclusive_exploit_path`, `_group_by_pattern`. `verify_result` public signature and `VerificationResult` return type are unchanged.

**`libs/openant-core/tests/test_local_claude.py`**
- Constructor change (`client=` is gone) means the old `TestVerifyWithNativeClaude` tests — which mocked `mock_client.messages.create` — cannot work as written. Rewrote the class to mock `utilities.finding_verifier.run_native_verification` instead. 6 new tests cover: structured JSON, JSON-in-code-block, free-text verdict fallback, unparseable text, SDK subprocess failure, and missing `repo_path`.

## Files not touched

Per the task brief: `pyproject.toml`, `llm_client.py`, `agentic_enhancer/agent.py`, `context_enhancer.py` are all untouched.

## Test plan

- [x] `python -c "from utilities.finding_verifier import FindingVerifier"` imports cleanly.
- [x] `pytest tests/test_local_claude.py` — 31/31 passing.
- [x] `pytest tests/test_resume_stage2.py` — 15/15 passing (covers `verify_batch` checkpoint/resume path, consistency cross-check still fires).
- [x] `pytest tests/test_declared_dependencies.py` — 8/8 passing (no undeclared imports; `anthropic` still declared in `pyproject.toml` and is still imported by other files — that's Steps 4-7's job).
- [x] `grep -n anthropic libs/openant-core/utilities/finding_verifier.py` — only the historical comment at line 8 remains; no import.
- [ ] End-to-end smoke: `openant verify` on a real finding. Deferred to Step 8 of the migration plan, covered by the issue-35 E2E checklist.
- [ ] Live rate-limit: verified centrally in PR #33's `_run_query` — not re-tested here.

## Notes

- The `client` constructor keyword is removed. Any external caller that still passes `FindingVerifier(client=...)` will hit `TypeError`. All in-tree callers (`experiment.py:695`, `core/verifier.py:138`, `tests/test_resume_stage2.py`) already construct without a `client` kwarg, so this only affected the `TestVerifyWithNativeClaude` test class (updated in this PR).
- PR #25's batch API (`checkpoint_path`, `concurrency`, `run_parallel`) is NOT restored here — `core/verifier.py` depends on the upstream `workers`/`checkpoint`/`restored_callback` surface. The upstream ThreadPoolExecutor-based batch code is kept verbatim.

Relates to #35.
