### PR TITLE
ci: cache pip, npm, and JS parser node_modules to speed up Windows runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,4 @@
 name: tests
-# Retrigger for warm-cache timing measurement.
 on:
   push:
     branches: [master]
@@ -20,6 +19,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Exclude workspace + toolchain caches from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $paths = @(
+            $env:GITHUB_WORKSPACE,
+            "$env:LOCALAPPDATA\go-build",
+            "$env:USERPROFILE\go\pkg\mod",
+            "$env:LOCALAPPDATA\npm-cache",
+            "$env:APPDATA\npm-cache"
+          )
+          foreach ($p in $paths) {
+            Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue
+          }
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -69,6 +83,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Exclude workspace + toolchain caches from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $paths = @(
+            $env:GITHUB_WORKSPACE,
+            "$env:LOCALAPPDATA\go-build",
+            "$env:USERPROFILE\go\pkg\mod",
+            "$env:LOCALAPPDATA\npm-cache",
+            "$env:APPDATA\npm-cache"
+          )
+          foreach ($p in $paths) {
+            Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue
+          }
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,21 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Exclude workspace + toolchain caches from Windows Defender
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $paths = @(
-            $env:GITHUB_WORKSPACE,
-            "$env:LOCALAPPDATA\go-build",
-            "$env:USERPROFILE\go\pkg\mod",
-            "$env:LOCALAPPDATA\npm-cache",
-            "$env:APPDATA\npm-cache"
-          )
-          foreach ($p in $paths) {
-            Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue
-          }
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -83,21 +68,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Exclude workspace + toolchain caches from Windows Defender
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $paths = @(
-            $env:GITHUB_WORKSPACE,
-            "$env:LOCALAPPDATA\go-build",
-            "$env:USERPROFILE\go\pkg\mod",
-            "$env:LOCALAPPDATA\npm-cache",
-            "$env:APPDATA\npm-cache"
-          )
-          foreach ($p in $paths) {
-            Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue
-          }
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
 name: tests
+# Retrigger for warm-cache timing measurement.
 on:
   push:
     branches: [master]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: libs/openant-core/pyproject.toml
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: libs/openant-core/parsers/javascript/package-lock.json
 
       - name: Install Python dependencies
         working-directory: libs/openant-core
@@ -38,9 +42,17 @@ jobs:
         working-directory: libs/openant-core
         run: ruff check .
 
+      - name: Cache JS parser node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: libs/openant-core/parsers/javascript/node_modules
+          key: ${{ runner.os }}-jsparser-nodemodules-${{ hashFiles('libs/openant-core/parsers/javascript/package-lock.json') }}
+
       - name: Install JS parser dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         working-directory: libs/openant-core/parsers/javascript
-        run: npm install
+        run: npm ci
 
       - name: Run Python and parser tests
         working-directory: libs/openant-core
@@ -67,11 +79,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: libs/openant-core/pyproject.toml
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: libs/openant-core/parsers/javascript/package-lock.json
 
       - name: Vet
         working-directory: apps/openant-cli
@@ -101,9 +117,17 @@ jobs:
         working-directory: libs/openant-core
         run: pip install -e ".[dev]"
 
+      - name: Cache JS parser node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: libs/openant-core/parsers/javascript/node_modules
+          key: ${{ runner.os }}-jsparser-nodemodules-${{ hashFiles('libs/openant-core/parsers/javascript/package-lock.json') }}
+
       - name: Install JS parser dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         working-directory: libs/openant-core/parsers/javascript
-        run: npm install
+        run: npm ci
 
       - name: Run Go CLI integration tests
         working-directory: libs/openant-core


### PR DESCRIPTION
## Summary

Windows CI is ~3–5× slower than Linux on this repo (Go job: 3m23s vs 1m13s on the last master run) because (a) the runner cold-extracts toolchains on every run, (b) Defender real-time scanning taxes NTFS metadata ops, and (c) nothing was cached between runs except the Go module/build dirs.

Three cache additions:

- `actions/setup-python@v5`: `cache: pip` keyed on `libs/openant-core/pyproject.toml`.
- `actions/setup-node@v5`: `cache: npm` keyed on `libs/openant-core/parsers/javascript/package-lock.json`.
- `actions/cache@v4`: cache `libs/openant-core/parsers/javascript/node_modules` directly, keyed on the lockfile hash. The `npm install` step is gated by `if: cache-hit != 'true'` so warm runs skip it entirely. Miss path uses `npm ci` for determinism.

`setup-go@v5` already caches `~/go/pkg/mod` + the build cache via `cache-dependency-path`, so no change there.

## Test plan

- [ ] First run on this branch repopulates all caches (expected: similar times to current master).
- [ ] Second run (no code change) should be notably faster on Windows — target Go job ~1m30s and Python jobs ~30–40s faster.
- [ ] `npm ci` miss-path still produces a working `node_modules/` (verified implicitly by existing JS parser tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)