### PR TITLE
fix: address medium CI/test review feedback from upstream-test-suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ jobs:
   python-tests:
     name: Python tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +33,7 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: libs/openant-core
-        run: pip install -r requirements.txt && pip install pytest
+        run: pip install -r requirements.txt && pip install ".[dev]"
 
       - name: Cache JS parser node_modules
         id: cache-node-modules
@@ -53,6 +54,9 @@ jobs:
   go-tests:
     name: Go build + integration (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      OPENANT_PYTHON: python
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +111,7 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: libs/openant-core
-        run: pip install -r requirements.txt && pip install pytest
+        run: pip install -r requirements.txt && pip install ".[dev]"
 
       - name: Cache JS parser node_modules
         id: cache-node-modules

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-          cache-dependency-path: libs/openant-core/requirements.txt
+          cache-dependency-path: |
+            libs/openant-core/requirements.txt
+            libs/openant-core/pyproject.toml
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -76,7 +78,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-          cache-dependency-path: libs/openant-core/requirements.txt
+          cache-dependency-path: |
+            libs/openant-core/requirements.txt
+            libs/openant-core/pyproject.toml
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -46,16 +46,31 @@ func venvPython() string {
 // DetectRuntime finds a suitable Python 3.11+ installation.
 //
 // Search order:
-//  1. OPENANT_PYTHON env var (if set and valid)
+//  1. OPENANT_PYTHON env var (if set and valid) — set this to pin a specific
+//     interpreter for debugging, CI, or container use (e.g. OPENANT_PYTHON=python3.11).
 //  2. Managed venv at ~/.openant/venv/ (if it exists and is valid)
 //  3. python3 / python on PATH
+//
+// Note: the managed-venv path (strategy 2) uses "bin/python" which is correct
+// on Linux/macOS. On Windows the venv layout uses "Scripts\python.exe"; users
+// on Windows who rely on the managed venv should set OPENANT_PYTHON explicitly
+// to point at the desired interpreter.
 func DetectRuntime() (*RuntimeInfo, error) {
-	// Strategy 0: honour explicit override via OPENANT_PYTHON env var
+	// Strategy 0: honour explicit override via OPENANT_PYTHON env var.
+	// If the override is set but unusable, warn and fall through rather than
+	// silently using a different interpreter behind the caller's back.
 	if override := os.Getenv("OPENANT_PYTHON"); override != "" {
-		if info, err := checkPython(override); err == nil {
-			if info.Major > MinPythonMajor || (info.Major == MinPythonMajor && info.Minor >= MinPythonMinor) {
-				return info, nil
-			}
+		info, err := checkPython(override)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: OPENANT_PYTHON=%q is not a usable Python binary (%v); ignoring override\n",
+				override, err)
+		} else if info.Major > MinPythonMajor || (info.Major == MinPythonMajor && info.Minor >= MinPythonMinor) {
+			return info, nil
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"warning: OPENANT_PYTHON=%q is Python %s, below the required %d.%d; ignoring override\n",
+				override, info.Version, MinPythonMajor, MinPythonMinor)
 		}
 	}
 

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -46,9 +46,19 @@ func venvPython() string {
 // DetectRuntime finds a suitable Python 3.11+ installation.
 //
 // Search order:
-//  1. Managed venv at ~/.openant/venv/ (if it exists and is valid)
-//  2. python3 / python on PATH
+//  1. OPENANT_PYTHON env var (if set and valid)
+//  2. Managed venv at ~/.openant/venv/ (if it exists and is valid)
+//  3. python3 / python on PATH
 func DetectRuntime() (*RuntimeInfo, error) {
+	// Strategy 0: honour explicit override via OPENANT_PYTHON env var
+	if override := os.Getenv("OPENANT_PYTHON"); override != "" {
+		if info, err := checkPython(override); err == nil {
+			if info.Major > MinPythonMajor || (info.Major == MinPythonMajor && info.Minor >= MinPythonMinor) {
+				return info, nil
+			}
+		}
+	}
+
 	// Strategy 1: check managed venv
 	vp := venvPython()
 	if fileExists(vp) {

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -123,7 +123,10 @@ class TestParse:
         )
         if result.returncode != 0:
             if "No module named" in result.stderr:
-                pytest.skip("Go CLI using system Python without required packages")
+                if sys.platform == "win32":
+                    pytest.skip("Go CLI using system Python without required packages (Windows)")
+                else:
+                    pytest.fail("Go CLI resolved wrong Python (missing required packages)")
             if "UnicodeEncodeError" in result.stderr:
                 pytest.skip("Pre-existing Unicode bug in JS test_pipeline.py on Windows")
         assert result.returncode == 0

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -128,7 +128,10 @@ class TestParse:
                 else:
                     pytest.fail("Go CLI resolved wrong Python (missing required packages)")
             if "UnicodeEncodeError" in result.stderr:
-                pytest.skip("Pre-existing Unicode bug in JS test_pipeline.py on Windows")
+                if sys.platform == "win32":
+                    pytest.skip("Pre-existing Unicode bug in JS test_pipeline.py on Windows")
+                else:
+                    pytest.fail("UnicodeEncodeError from JS parser on non-Windows (unexpected regression)")
         assert result.returncode == 0
         envelope = json.loads(result.stdout)
         assert envelope["status"] == "success"


### PR DESCRIPTION
Addresses all four medium-severity items from the CI/test review.

## Changes

### 1. Job-level `timeout-minutes: 15` (`.github/workflows/test.yaml`)
Both `python-tests` and `go-tests` previously relied on the 360-minute GitHub Actions default. `pip install`, `npm ci`, and `go build` steps are now bounded — a stalled registry can no longer burn hours of runner time.

### 2. `pip install ".[dev]"` replaces `pip install pytest` (`.github/workflows/test.yaml`)
Both jobs were bypassing the `[project.optional-dependencies] dev` extra declared in `pyproject.toml` and installing an unpinned `pytest` directly. Now CI installs through the declared extra, so any future dev tooling added to `[dev]` (mypy, ruff, etc.) is automatically picked up.

### 3. Platform-gated `pytest.skip` for "No module named" (`libs/openant-core/tests/test_go_cli.py`)
`test_parse_js_repo` previously skipped unconditionally on any `"No module named"` error, hiding regressions on Linux/macOS. Now:
- **Windows**: `pytest.skip` (pre-existing Python resolution ambiguity)
- **Linux/macOS**: `pytest.fail` with a clear message (should never happen with the correct env, so a failure here is a real regression)

### 4. `OPENANT_PYTHON` env var support for explicit Python resolution (`apps/openant-cli/internal/python/runtime.go` + workflow)
`DetectRuntime()` gains a new top-priority strategy: if `OPENANT_PYTHON` is set in the environment, that binary is used before the managed venv or PATH scan. The `go-tests` job sets `OPENANT_PYTHON: python` at the job level, which always resolves to the `actions/setup-python`-installed interpreter on all platforms — eliminating the implicit resolution ambiguity on Windows.

## Test plan
- [ ] CI passes on ubuntu-latest for both jobs
- [ ] Confirm `pip install ".[dev]"` succeeds (pyproject.toml `[dev]` extra resolves correctly from `libs/openant-core` working directory)
- [ ] Confirm `test_parse_js_repo` skips on Windows and fails fast (not silently skips) on Linux if packages are missing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tar2Pyn97wA1c8c7zap84i)_